### PR TITLE
Added support for CSV Transformations.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,3 @@
 exports.TemplateHelper = require('./lib/TemplateHelper');
+exports.JSONHelper = require('./lib/JSONHelper');
+exports.XSVHelper = require('./lib/XSVHelper');

--- a/lib/JSONHelper.js
+++ b/lib/JSONHelper.js
@@ -1,0 +1,17 @@
+class JSONHelper {
+  /**
+   * Validates that a passed string can be parsed as JSON and return it as an object.
+   *
+   * @param inputjson
+   * @returns {null|any}
+   */
+  static parseJson(inputjson) {
+    try {
+      return JSON.parse(inputjson);
+    } catch (e) {
+      return null;
+    }
+  }
+}
+
+module.exports = JSONHelper;

--- a/lib/TemplateHelper.js
+++ b/lib/TemplateHelper.js
@@ -14,8 +14,28 @@ class TemplateHelper {
    * @param removeNewline
    * @returns {string}
    */
-  static applyTemplate(templateFilepath, contextData, removeNewline = true) {
+  static applyTemplateWithFilePath(
+    templateFilepath,
+    contextData,
+    removeNewline = true
+  ) {
     const templateBody = TemplateHelper.loadTemplate(templateFilepath);
+    return TemplateHelper.applyTemplate(
+      templateBody,
+      contextData,
+      removeNewline
+    );
+  }
+
+  /**
+   * Applies a template (by file name) to the passed data. Optionally removes newline characters from the output.
+   *
+   * @param templateBody
+   * @param contextData
+   * @param removeNewline
+   * @returns {string}
+   */
+  static applyTemplate(templateBody, contextData, removeNewline = true) {
     // TODO: Add safety code to check templateBody is something before compiling.
     // TODO: Wrap the compile in try catch that returns empty string
     const templateRuntime = handlebars.compile(templateBody);

--- a/lib/XSVHelper.js
+++ b/lib/XSVHelper.js
@@ -1,0 +1,43 @@
+const parse = require('csv-parse/lib/sync');
+
+class XSVHelper {
+  /**
+   * Returns a csv parse options object that can be passed into the parser.
+   *
+   * @param delimiter - expected to be the delimiter for the xSV file.
+   * @param columns - expected to be a comma separated string of column names
+   * @returns {{delimiter: *, columns: []}}
+   */
+  static getCsvOptionsObject(delimiter, columns) {
+    if (!delimiter || !columns) {
+      throw new Error(
+        'getCsvOptionsObject - arguments "delimiter" and "columns" must both be non-null.'
+      );
+    }
+    return {
+      delimiter: delimiter,
+      // Note we split the incoming columns string into an array, and trim any whitespace between the delimiters
+      columns: columns.split(',').map((s) => s.trim()),
+      // Trim any whitespace around the delimiter (but not inside any quoted strings)
+      trim: true,
+    };
+  }
+
+  /**
+   * Parses an input string expected to contain a xSV structure with the passed delimiter
+   * @param input - a string of text, delimited properly by the passed delimiter.
+   * @param delimiter - a delimiter that separates distinct columns in the input
+   * @param columnLayout - the layout of column names that matches the input string
+   * @returns {any}
+   */
+  static parseXsv(input, delimiter, columnLayout) {
+    try {
+      const optionsObject = this.getCsvOptionsObject(delimiter, columnLayout);
+      return parse(input, optionsObject);
+    } catch (e) {
+      throw new Error(`parseXsv - ${e.message}`);
+    }
+  }
+}
+
+module.exports = XSVHelper;

--- a/node_modules/csv-parse/CHANGELOG.md
+++ b/node_modules/csv-parse/CHANGELOG.md
@@ -1,0 +1,540 @@
+
+# Changelog
+
+## Todo
+
+* `skip_lines_with_empty_values`: rename to skip_records_with_empty_values
+* `skip_lines_with_error`: rename to skip_records_with_error
+* `relax`: rename to relax_quotes_when_unquoted
+* `max_comment_size`: new option
+* promise: new API module
+* errors: finish normalisation of all errors
+
+## Version 4.8.9
+
+Fix:
+* sync: disregard emitted null records
+
+New Feature:
+* trim: support form feed character
+
+Minor improvements:
+* src: cache length in loops
+* trim: new sample
+* to_line: simple sample
+* comment: simple sample
+* bom: sample with hidden bom
+* bom: test behavior with the column option
+
+## Version 4.8.8
+
+* api: fix regression in browser environments
+
+## Version 4.8.7
+
+* api: fix input string with output stream
+
+## Version 4.8.6
+
+* on_record: catch and handle user errors
+
+## Version 4.8.5
+
+* ts: fix `types` declaration
+
+## Version 4.8.4
+
+* ts: fix `types` declaration to a single file
+
+## Version 4.8.3
+
+* `errors`: handle undefined captureStackTrace
+
+## Version 4.8.2
+
+* `relax_column_count`: ts definitions for less and more
+
+## Version 4.8.1
+
+* package: move pad dependency to dev
+
+## Version 4.8.0
+
+* `relax_column_count`: new less and more options
+* columns: skip empty records before detecting headers
+* errors: rename `CSV_INCONSISTENT_RECORD_LENGTH`
+* errors: rename `CSV_RECORD_DONT_MATCH_COLUMNS_LENGTH`
+
+## Version 4.7.0
+
+New Feature:
+* `on_record`: user function to alter and filter records
+
+Minor improvements:
+* test: ensure every sample is valid
+* `from_line`: honours inferred column names
+* `from_line`: new sample
+* errors: expose `CSV_INVALID_ARGUMENT`
+* errors: expose `CSV_INVALID_COLUMN_DEFINITION`
+* errors: expose `CSV_OPTION_COLUMNS_MISSING_NAME`
+* errors: expose `CSV_INVALID_OPTION_BOM`
+* errors: expose `CSV_INVALID_OPTION_CAST`
+* errors: expose `CSV_INVALID_OPTION_CAST_DATE`
+* errors: expose `CSV_INVALID_OPTION_COLUMNS`
+* errors: expose `CSV_INVALID_OPTION_COMMENT`
+* errors: expose `CSV_INVALID_OPTION_DELIMITER`
+* error: fix call to supper
+
+Project management:
+* package: contributing
+* package: code of conduct
+
+## Version 4.6.5
+
+* context: column is null when cast force the context creation, fix #260
+
+## Version 4.6.4
+
+* errors: don't stringify/parse undefined and null values
+* errors: expose `CSV_NON_TRIMABLE_CHAR_AFTER_CLOSING_QUOTE`
+* errors: expose `CSV_MAX_RECORD_SIZE`
+
+## Version 4.6.3
+
+* lint: integrate eslint
+
+## Version 4.6.2
+
+* context: null column when columns number inferior to record length
+
+## Version 4.6.1
+
+* src: set const in for loop
+
+## Version 4.6.0
+
+* `skip_lines_with_empty_values`: handle non string value
+* errors: add context information
+* tests: new error assertion framework
+* buffer: serialize to json as string
+* errors: expose `INVALID_OPENING_QUOTE`
+
+## Version 4.5.0
+
+* errors: start normalizing errors with unique codes and context
+* errors: expose `CSV_INVALID_CLOSING_QUOTE`
+* errors: expose `CSV_QUOTE_NOT_CLOSED`
+* errors: expose `CSV_INVALID_RECORD_LENGTH_DONT_PREVIOUS_RECORDS`
+* errors: expose `CSV_INVALID_RECORD_LENGTH_DONT_MATCH_COLUMNS`
+* errors: expose `CSV_INVALID_COLUMN_MAPPING`
+
+## Version 4.4.7
+
+* travis: remove node.js 8 and add 12
+* destroy: test inside readable event
+
+## Version 4.4.6
+
+* security: remove regexp vulnerable to DOS in cast option, npm report 69742
+
+## Version 4.4.5
+
+* ts: add buffer as allowed type for input, fix #248
+
+## Version 4.4.4
+
+* package: latest dependencies
+* bom: detection when buffer smaller than bom
+* package: remove deprecated `@types/should` dependency
+* package: update file path
+
+## Version 4.4.3
+
+* package: fix files declaration
+
+## Version 4.4.2
+
+* `bom`: parsing for BOM character #239
+* ts: add sync definition
+* package: replace npm ignore with file field
+
+## Version 4.4.1
+
+Fix:
+* `columns`: allows returning an array of string, undefined, null or false
+
+## Version 4.4.0
+
+New features:
+* options: new `bom` option
+
+## Version 4.3.4
+
+* `columns`: enrich error message when provided as literal object
+* `cast`: handle undefined columns
+* `skip_lines_with_error`: new sample
+
+## Version 4.3.3
+
+Fix:
+columns: fix es5 generation
+
+## Version 4.3.2
+
+Fix:
+* columns: immutable option
+
+## Version 4.3.1
+
+Minor enhancements:
+* ts: distribute definitions with es5
+* ts: unused MatcherFunc type
+
+Project management:
+* babel: include .babelrc to git
+
+## Version 4.3.0
+
+New features:
+* `objname`: accept a buffer
+
+Minor enhancements:
+* `to_line`: validation refinements
+* `trim`, ltrim, rtrim: validation refinements
+* `to`: validation refinements
+* `from_line`: validation refinements
+* `objname`: validation refinements
+* `from`: validation refinements
+* `escape`: validation refinements
+* `skip_empty_lines`: validation refinements
+* `skip_lines_with_empty_values`: validation refinements
+* `skip_lines_with_error`: validation refinements
+* `relax_column_count`: validation refinements
+* `relax`: validation refinements
+* `delimiter`: validation refinements
+* `max_record_size`: validation refinements
+
+## Version 4.2.0
+
+Fix:
+* `record_delimiter`: fix multi bytes with `skip_empty_lines` and `from_line`
+* `rtrim`: accept tab
+
+## Version 4.1.0
+
+New features:
+* options: accept snake case and camel case
+* `cast`: dont call cast for non column-mappable fields
+
+Fix:
+* `cast`: ensure column is a string and not an array
+* stream: handle empty input streams
+* `cast`: function may return non-string values
+* stream: pass stream options without modification
+
+## Version 4.0.1
+
+Fix:
+* `relax_column_count`: handle records with more columns
+
+## Version 4.0.0
+
+This is a complete rewrite based with a Buffer implementation. There are no major breaking changes but it introduces multiple minor breaking changes:
+
+* option `rowDelimiter` is now `record_delimiter`
+* option `max_limit_on_data_read` is now `max_record_size`
+* drop the record event
+* normalise error message as `{error type}: {error description}`
+* state values are now isolated into the `info` object
+* `count` is now `info.records`
+* `lines` is now `info.lines`
+* `empty_line_count` is now `info.empty_lines`
+* `skipped_line_count` is now `info.invalid_field_length`
+* `context.count` is cast function is now `context.records`
+* drop support for deprecated options `auto_parse` and `auto_parse_date`
+* drop emission of the `record` event
+* in `raw` option, the `row` property is renamed `record`
+* default value of `max_record_size` is now `0` (unlimited)
+* remove the `record` event, use the `readable` event and `this.read()` instead
+
+New features:
+* new options `info`, `from_line` and `to_line`
+* `trim`: respect `ltrim` and `rtrim` when defined
+* `delimiter`: may be a Buffer
+* `delimiter`: handle multiple bytes/characters
+* callback: export info object as third argument
+* `cast`: catch error in user functions
+* ts: mark info as readonly with required properties
+* `comment_lines`: count the number of commented lines with no records
+* callback: pass undefined instead of null
+
+API management:
+* Multiple tests have been rewritten with easier data sample
+* Source code is now written in ES6 instead of CoffeeScript
+* package: switch to MIT license
+
+## Version 3.2.0
+
+* `max_limit_on_data_read`: update error msg
+* src: simplify detection for more data
+* lines: test empty line account for 1 line
+* options: extract default options
+* package: add a few keywords
+* src: precompute escapeIsQuote
+* travis: test against Node.js 11
+
+## Version 3.1.3
+
+* `rowDelimiter`: fix overlap with delimiter
+* internal: rename rowDelimiterLength to `rowDelimiterMaxLength`
+
+## Version 3.1.2
+
+* readme: fix links to project website
+
+## Version 3.1.1
+
+* src: generate code
+
+## Version 3.1.0
+
+* package: move to csv.js.org
+* samples: new cast sample
+* package: upgrade to babel 7
+* samples: new mixed api samples
+* samples: new column script
+* samples: update syntax
+* package: improve ignore files
+
+## Version 3.0.0
+
+Breaking changes:
+* `columns`: skip empty values when null, false or undefined
+
+Cleanup:
+* sync: refactor internal variables
+* index: use destructuring assignment for deps
+
+## Version 2.5.0
+
+* typescript: make definition header more relevant
+
+## Version 2.4.1
+
+* `to`: ignore future records when to is reached
+
+## Version 2.4.0
+
+* `trim`: after and before quote
+* tests: compatibility with Node.js 10
+* `trim`: handle quote followed by escape
+* parser: set nextChar to null instead of empty
+* travis: run against node 8 and 10
+
+## Version 2.3.0
+
+* `cast`: pass the header property
+* `auto_parse`: deprecated message on tests
+* `cast`: inject lines property
+
+## Version 2.2.0
+
+* `cast`: deprecate `auto_parse`
+* `auto_parse`: function get context as second argument
+
+## Version 2.1.0
+
+* `skip_lines_with_error`: DRYed implementation
+* `skip_lines_with_error`: Go process the next line on error
+* events: register and write not blocking
+* test: prefix names by group membership
+* events: emit record
+* raw: test to ensure it preserve columns
+* package: latest dependencies (28 march 2018)
+* raw: ensure tests call and success
+* package: ignore npm and yarn lock files
+* sync: handle errors on last line
+
+## Version 2.0.4
+
+* package: move babel to dev dependencies
+
+## Version 2.0.3
+
+* package: es5 backward compatibility
+* package: ignore yarn lock file
+
+## Version 2.0.2
+
+* package: only remove js files in lib
+* source: remove unreferenced variables #179
+* package: start running tests in preversion
+* package: new release workflow
+
+## 2.0.0
+
+This major version use CoffeeScript 2 which produces a modern JavaScript syntax 
+(ES6, or ES2015 and later) and break the compatibility with versions of Node.js 
+lower than 7.6 as well as the browsers. It is however stable in term of API.
+
+* package: use CoffeeScript 2
+
+## v1.3.3
+
+* package: revert to CoffeeScript 1
+
+## v1.3.2
+
+Irrelevant release, forgot to generate the coffee files.
+
+## v1.3.1
+
+* package: preserve compatibility with Node.js < 7.6
+
+## v1.3.0
+
+* options: `auto_parse` as a user function
+* options: `auto_parse_date` as a user function
+* test: should require handled by mocha
+* package: coffeescript 2 and use semver tilde
+* options: ensure objectMode is cloned
+
+## v1.2.4
+
+* `relax_column_count`: honors count while preserving skipped_line_count
+* api: improve argument validation 
+
+## v1.2.3
+
+* sync: catch err on write
+
+## v1.2.2
+
+* relax: handle double quote
+
+## v1.2.1
+
+* src: group state variable initialisation
+* package: update repo url
+* quote: disabled when null, false or empty
+* src: remove try/catch
+* src: optimize estimation for row delimiter length
+* lines: improve tests
+* src: use in instead of multiple is
+* src: string optimization
+
+## v1.2.0
+
+* skip default row delimiters when quoted #58
+* `auto_parse`: cleaner implementation
+* src: isolate internal variables
+
+## v1.1.12
+
+* options: new to and from options
+
+## v1.1.11
+
+* `rowDelimiters`: fix all last month issues
+
+## v1.1.10
+
+* regression with trim and last empty field #123
+
+## V1.1.9
+
+* `rowDelimiter`: simplification
+* fix regression when trim and skip_empty_lines activated #122
+* `auto_parse` = simplify internal function
+
+## V1.1.8
+
+* src: trailing whitespace and empty headers #120
+* `rowDelimiter`: adding support for multiple row delimiters #119
+* Remove unnecessary argument: `Parser.prototype.__write` #114
+
+## v1.1.7
+
+* `skip_lines_with_empty_values`: support space and tabs #108
+* test: remove coverage support
+* test: group by api, options and properties
+* `skip_lines_with_empty_values` option
+* write test illustrating column function throwing an error #98
+* added ability to skip columns #50
+
+## v1.1.6
+
+* reduce substr usage
+* new raw option
+
+## v1.1.5
+
+* `empty_line_count` counter and renamed skipped to `skipped_line_count`
+* skipped line count
+
+## v1.1.4
+
+* avoid de-optimisation due to wrong charAt index #103
+* parser writing before assigning listeners
+
+## v1.1.3
+
+* `columns`: stop on column count error #100
+
+## v1.1.2
+
+* make the parser more sensitive to input
+* test case about the chunks of multiple chars without quotes
+* test about data emission with newline
+
+## v1.1.1
+
+* stream: call end if data instance of buffer
+* travis: add nodejs 6
+* `columns`: fix line error #97
+
+## v1.1.0
+
+* `relax_column_count`: default to false (strict)
+
+## v1.0.6
+
+* `relax_column_count`: backward compatibility for 1.0.x
+* `relax_column_count`: introduce new option
+* `columns`: detect column length and fix lines count
+
+## v1.0.5
+
+* fix quotes tests that used data with inconsistent number of #73
+* add tests for inconsistent number of columns #73
+* throw an error when a column is missing #73
+* travis: test nodejs versions 4, 5
+* `max_limit_on_data_read`: new option
+* removing the duplicate files in test and samples #86
+* option argument to accept the number of bytes can be read #86
+* avoid unwanted parsing when there is wrong delimiter or row delimiter #86
+
+## v1.0.4
+
+* sync: support `objname`
+
+## v1.0.3
+
+* sync: please older versions of node.js
+* sync: new sample
+
+## v1.0.2
+
+* sync: new module
+* removed global variable record on stream.js example #70
+
+## v1.0.1
+
+* api: accept buffer with 3 arguments #57
+* package: latest dependencies
+* spectrum: bypass regression test
+
+## v1.0.0
+
+* `auto_parse`: work on all fields, rename to “is_*”
+* `auto_parse`: simplify test

--- a/node_modules/csv-parse/LICENSE
+++ b/node_modules/csv-parse/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2010 Adaltas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/node_modules/csv-parse/README.md
+++ b/node_modules/csv-parse/README.md
@@ -1,0 +1,27 @@
+
+# CSV Parser for Node.js
+
+[![Build Status](https://api.travis-ci.org/adaltas/node-csv-parse.svg)](https://travis-ci.org/#!/adaltas/node-csv-parse)
+
+Part of the [CSV module](https://csv.js.org/), this project is a parser converting CSV text input into arrays or objects. It implements the Node.js [`stream.Transform` API](http://nodejs.org/api/stream.html#stream_class_stream_transform). It also provides a simple callback-based API for convenience. It is both extremely easy to use and powerful. It was first released in 2010 and is used against big data sets by a large community.
+
+## Documentation
+
+* [Project homepage](http://csv.js.org/parse/)
+* [API](http://csv.js.org/parse/api/)
+* [Options](http://csv.js.org/parse/options/)
+* [Info properties](http://csv.js.org/parse/info/)
+* [Common errors](http://csv.js.org/parse/errors/)
+* [Examples](http://csv.js.org/project/examples/)
+
+## Features
+
+*   Follow the Node.js streaming API
+*   Simplicity with the optional callback API
+*   Support delimiters, quotes, escape characters and comments
+*   Line breaks discovery
+*   Support big datasets
+*   Complete test coverage and samples for inspiration
+*   No external dependencies
+*   Work nicely with the [csv-generate](https://csv.js.org/generate/), [stream-transform](https://csv.js.org/transform/) and [csv-stringify](https://csv.js.org/stringify/) packages
+*   MIT License

--- a/node_modules/csv-parse/lib/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/node_modules/csv-parse/lib/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,20 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+
+A clear and concise description of what the bug is, the CSV package version you are using.
+
+**To Reproduce**
+
+Please provide us with a unit test, an example code or even pseudo-code. It could be written in JavaScript or CoffeeScript, it doesn't matter. What's important is to limit the data to the minimum as well as to strip down the number of options to the only ones with an impact.
+
+**Additional context**
+
+Add any other context about the problem here.

--- a/node_modules/csv-parse/lib/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/node_modules/csv-parse/lib/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+
+Add any other context or screenshots about the feature request here.

--- a/node_modules/csv-parse/lib/ResizeableBuffer.js
+++ b/node_modules/csv-parse/lib/ResizeableBuffer.js
@@ -1,0 +1,46 @@
+
+
+class ResizeableBuffer{
+  constructor(size=100){
+    this.size = size
+    this.length = 0
+    this.buf = Buffer.alloc(size)
+  }
+  prepend(val){
+    const length = this.length++
+    if(length === this.size){
+      this.resize()
+    }
+    const buf = this.clone()
+    this.buf[0] = val
+    buf.copy(this.buf,1, 0, length)
+  }
+  append(val){
+    const length = this.length++
+    if(length === this.size){
+      this.resize()
+    }
+    this.buf[length] = val
+  }
+  clone(){
+    return Buffer.from(this.buf.slice(0, this.length))
+  }
+  resize(){
+    const length = this.length
+    this.size = this.size * 2
+    const buf = Buffer.alloc(this.size)
+    this.buf.copy(buf,0, 0, length)
+    this.buf = buf
+  }
+  toString(){
+    return this.buf.slice(0, this.length).toString()
+  }
+  toJSON(){
+    return this.toString()
+  }
+  reset(){
+    this.length = 0
+  }
+}
+
+module.exports = ResizeableBuffer

--- a/node_modules/csv-parse/lib/es5/ResizeableBuffer.js
+++ b/node_modules/csv-parse/lib/es5/ResizeableBuffer.js
@@ -1,0 +1,78 @@
+"use strict";
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+var ResizeableBuffer = /*#__PURE__*/function () {
+  function ResizeableBuffer() {
+    var size = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 100;
+
+    _classCallCheck(this, ResizeableBuffer);
+
+    this.size = size;
+    this.length = 0;
+    this.buf = Buffer.alloc(size);
+  }
+
+  _createClass(ResizeableBuffer, [{
+    key: "prepend",
+    value: function prepend(val) {
+      var length = this.length++;
+
+      if (length === this.size) {
+        this.resize();
+      }
+
+      var buf = this.clone();
+      this.buf[0] = val;
+      buf.copy(this.buf, 1, 0, length);
+    }
+  }, {
+    key: "append",
+    value: function append(val) {
+      var length = this.length++;
+
+      if (length === this.size) {
+        this.resize();
+      }
+
+      this.buf[length] = val;
+    }
+  }, {
+    key: "clone",
+    value: function clone() {
+      return Buffer.from(this.buf.slice(0, this.length));
+    }
+  }, {
+    key: "resize",
+    value: function resize() {
+      var length = this.length;
+      this.size = this.size * 2;
+      var buf = Buffer.alloc(this.size);
+      this.buf.copy(buf, 0, 0, length);
+      this.buf = buf;
+    }
+  }, {
+    key: "toString",
+    value: function toString() {
+      return this.buf.slice(0, this.length).toString();
+    }
+  }, {
+    key: "toJSON",
+    value: function toJSON() {
+      return this.toString();
+    }
+  }, {
+    key: "reset",
+    value: function reset() {
+      this.length = 0;
+    }
+  }]);
+
+  return ResizeableBuffer;
+}();
+
+module.exports = ResizeableBuffer;

--- a/node_modules/csv-parse/lib/es5/index.d.ts
+++ b/node_modules/csv-parse/lib/es5/index.d.ts
@@ -1,0 +1,207 @@
+// Original definitions in https://github.com/DefinitelyTyped/DefinitelyTyped by: David Muller <https://github.com/davidm77>
+
+/// <reference types="node" />
+
+import * as stream from "stream";
+
+export = parse;
+
+declare function parse(input: Buffer | string, options?: parse.Options, callback?: parse.Callback): parse.Parser;
+declare function parse(input: Buffer | string, callback?: parse.Callback): parse.Parser;
+declare function parse(options?: parse.Options, callback?: parse.Callback): parse.Parser;
+declare function parse(callback?: parse.Callback): parse.Parser;
+declare namespace parse {
+
+    type Callback = (err: Error | undefined, records: any | undefined, info: Info) => void;
+
+    interface Parser extends stream.Transform {}
+
+    class Parser {
+        constructor(options: Options);
+        
+        __push(line: any): any;
+        
+        __write(chars: any, end: any, callback: any): any;
+        
+        readonly options: Options
+        
+        readonly info: Info;
+    }
+
+    interface CastingContext {
+        readonly column: number | string;
+        readonly empty_lines: number;
+        readonly header: boolean;
+        readonly index: number;
+        readonly quoting: boolean;
+        readonly lines: number;
+        readonly records: number;
+        readonly invalid_field_length: number;
+    }
+
+    type CastingFunction = (value: string, context: CastingContext) => any;
+
+    type CastingDateFunction = (value: string, context: CastingContext) => Date;
+
+    type ColumnOption = string | undefined | null | false | { name: string };
+
+    interface Options {
+        /**
+         * If true, the parser will attempt to convert read data types to native types.
+         * @deprecated Use {@link cast}
+         */
+        auto_parse?: boolean | CastingFunction;
+        /**
+         * If true, the parser will attempt to convert read data types to dates. It requires the "auto_parse" option.
+         * @deprecated Use {@link cast_date}
+         */
+        auto_parse_date?: boolean | CastingDateFunction;
+        /**
+         * If true, detect and exclude the byte order mark (BOM) from the CSV input if present.
+         */
+        bom?: boolean;
+        /**
+         * If true, the parser will attempt to convert input string to native types.
+         * If a function, receive the value as first argument, a context as second argument and return a new value. More information about the context properties is available below.
+         */
+        cast?: boolean | CastingFunction;
+        /**
+         * If true, the parser will attempt to convert input string to dates.
+         * If a function, receive the value as argument and return a new value. It requires the "auto_parse" option. Be careful, it relies on Date.parse.
+         */
+        cast_date?: boolean | CastingDateFunction;
+        /**
+         * List of fields as an array,
+         * a user defined callback accepting the first line and returning the column names or true if autodiscovered in the first CSV line,
+         * default to null,
+         * affect the result data set in the sense that records will be objects instead of arrays.
+         */
+        columns?: ColumnOption[] | boolean | ((record: any) => ColumnOption[]);
+        /**
+         * Treat all the characters after this one as a comment, default to '' (disabled).
+         */
+        comment?: string;
+        /**
+         * Set the field delimiter. One character only, defaults to comma.
+         */
+        delimiter?: string | Buffer;
+        /**
+         * Set the escape character, one character only, defaults to double quotes.
+         */
+        escape?: string | Buffer;
+        /**
+         * Start handling records from the requested number of records.
+         */
+        from?: number;
+        /**
+         * Start handling records from the requested line number.
+         */
+        from_line?: number;
+        /**
+         * Generate two properties `info` and `record` where `info` is a snapshot of the info object at the time the record was created and `record` is the parsed array or object.
+         */
+        info?: boolean;
+        /**
+         * If true, ignore whitespace immediately following the delimiter (i.e. left-trim all fields), defaults to false.
+         * Does not remove whitespace in a quoted field.
+         */
+        ltrim?: boolean;
+        /**
+         * Maximum numer of characters to be contained in the field and line buffers before an exception is raised,
+         * used to guard against a wrong delimiter or record_delimiter,
+         * default to 128000 characters.
+         */
+        max_record_size?: number;
+        /**
+         * Name of header-record title to name objects by.
+         */
+        objname?: string;
+        /**
+         * Alter and filter records by executing a user defined function.
+         */
+        on_record?: (record: any, context: CastingContext) => any;
+        /**
+         * Optional character surrounding a field, one character only, defaults to double quotes.
+         */
+        quote?: string | boolean | Buffer | null;
+        /**
+         * Generate two properties raw and row where raw is the original CSV row content and row is the parsed array or object.
+         */
+        raw?: boolean;
+        /**
+         * Preserve quotes inside unquoted field.
+         */
+        relax?: boolean;
+        /**
+         * Discard inconsistent columns count, default to false.
+         */
+        relax_column_count?: boolean;
+        /**
+         * Discard inconsistent columns count when the record contains less fields than expected, default to false.
+         */
+        relax_column_count_less?: boolean;
+        /**
+         * Discard inconsistent columns count when the record contains more fields than expected, default to false.
+         */
+        relax_column_count_more?: boolean;
+        /**
+         * One or multiple characters used to delimit record rows; defaults to auto discovery if not provided.
+         * Supported auto discovery method are Linux ("\n"), Apple ("\r") and Windows ("\r\n") row delimiters.
+         */
+        record_delimiter?: string | string[] | Buffer | Buffer[];
+        /**
+         * If true, ignore whitespace immediately preceding the delimiter (i.e. right-trim all fields), defaults to false.
+         * Does not remove whitespace in a quoted field.
+         */
+        rtrim?: boolean;
+        /**
+         * Dont generate empty values for empty lines.
+         * Defaults to false
+         */
+        skip_empty_lines?: boolean;
+        /**
+         * Skip a line with error found inside and directly go process the next line.
+         */
+        skip_lines_with_error?: boolean;
+        /**
+         * Don't generate records for lines containing empty column values (column matching /\s*\/), defaults to false.
+         */
+        skip_lines_with_empty_values?: boolean;
+        /**
+         * Stop handling records after the requested number of records.
+         */
+        to?: number;
+        /**
+         * Stop handling records after the requested line number.
+         */
+        to_line?: number;
+        /**
+         * If true, ignore whitespace immediately around the delimiter, defaults to false.
+         * Does not remove whitespace in a quoted field.
+         */
+        trim?: boolean;
+    }
+
+    interface Info {
+        /**
+         * Count the number of lines being fully commented.
+         */
+        readonly comment_lines: number;
+        /**
+         * Count the number of processed empty lines.
+         */
+        readonly empty_lines: number;
+        /**
+         * The number of lines encountered in the source dataset, start at 1 for the first line.
+         */
+        readonly lines: number;
+        /**
+         * Count the number of processed records.
+         */
+        readonly records: number;
+        /**
+         * Number of non uniform records when `relax_column_count` is true.
+         */
+        readonly invalid_field_length: number;
+    }
+}

--- a/node_modules/csv-parse/lib/es5/index.js
+++ b/node_modules/csv-parse/lib/es5/index.js
@@ -1,0 +1,1353 @@
+"use strict";
+
+function _wrapNativeSuper(Class) { var _cache = typeof Map === "function" ? new Map() : undefined; _wrapNativeSuper = function _wrapNativeSuper(Class) { if (Class === null || !_isNativeFunction(Class)) return Class; if (typeof Class !== "function") { throw new TypeError("Super expression must either be null or a function"); } if (typeof _cache !== "undefined") { if (_cache.has(Class)) return _cache.get(Class); _cache.set(Class, Wrapper); } function Wrapper() { return _construct(Class, arguments, _getPrototypeOf(this).constructor); } Wrapper.prototype = Object.create(Class.prototype, { constructor: { value: Wrapper, enumerable: false, writable: true, configurable: true } }); return _setPrototypeOf(Wrapper, Class); }; return _wrapNativeSuper(Class); }
+
+function isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
+function _construct(Parent, args, Class) { if (isNativeReflectConstruct()) { _construct = Reflect.construct; } else { _construct = function _construct(Parent, args, Class) { var a = [null]; a.push.apply(a, args); var Constructor = Function.bind.apply(Parent, a); var instance = new Constructor(); if (Class) _setPrototypeOf(instance, Class.prototype); return instance; }; } return _construct.apply(null, arguments); }
+
+function _isNativeFunction(fn) { return Function.toString.call(fn).indexOf("[native code]") !== -1; }
+
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _nonIterableRest(); }
+
+function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance"); }
+
+function _iterableToArrayLimit(arr, i) { if (!(Symbol.iterator in Object(arr) || Object.prototype.toString.call(arr) === "[object Arguments]")) { return; } var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
+
+function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _nonIterableSpread(); }
+
+function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance"); }
+
+function _iterableToArray(iter) { if (Symbol.iterator in Object(iter) || Object.prototype.toString.call(iter) === "[object Arguments]") return Array.from(iter); }
+
+function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = new Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } }
+
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+/*
+CSV Parse
+
+Please look at the [project documentation](https://csv.js.org/parse/) for
+additional information.
+*/
+var _require = require('stream'),
+    Transform = _require.Transform;
+
+var ResizeableBuffer = require('./ResizeableBuffer');
+
+var tab = 9;
+var nl = 10;
+var np = 12;
+var cr = 13;
+var space = 32;
+var bom_utf8 = Buffer.from([239, 187, 191]);
+
+var Parser = /*#__PURE__*/function (_Transform) {
+  _inherits(Parser, _Transform);
+
+  function Parser() {
+    var _this;
+
+    var opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+
+    _classCallCheck(this, Parser);
+
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(Parser).call(this, _objectSpread({}, {
+      readableObjectMode: true
+    }, {}, opts)));
+    var options = {}; // Merge with user options
+
+    for (var opt in opts) {
+      options[underscore(opt)] = opts[opt];
+    } // Normalize option `bom`
+
+
+    if (options.bom === undefined || options.bom === null || options.bom === false) {
+      options.bom = false;
+    } else if (options.bom !== true) {
+      throw new CsvError('CSV_INVALID_OPTION_BOM', ['Invalid option bom:', 'bom must be true,', "got ".concat(JSON.stringify(options.bom))]);
+    } // Normalize option `cast`
+
+
+    var fnCastField = null;
+
+    if (options.cast === undefined || options.cast === null || options.cast === false || options.cast === '') {
+      options.cast = undefined;
+    } else if (typeof options.cast === 'function') {
+      fnCastField = options.cast;
+      options.cast = true;
+    } else if (options.cast !== true) {
+      throw new CsvError('CSV_INVALID_OPTION_CAST', ['Invalid option cast:', 'cast must be true or a function,', "got ".concat(JSON.stringify(options.cast))]);
+    } // Normalize option `cast_date`
+
+
+    if (options.cast_date === undefined || options.cast_date === null || options.cast_date === false || options.cast_date === '') {
+      options.cast_date = false;
+    } else if (options.cast_date === true) {
+      options.cast_date = function (value) {
+        var date = Date.parse(value);
+        return !isNaN(date) ? new Date(date) : value;
+      };
+    } else if (typeof options.cast_date !== 'function') {
+      throw new CsvError('CSV_INVALID_OPTION_CAST_DATE', ['Invalid option cast_date:', 'cast_date must be true or a function,', "got ".concat(JSON.stringify(options.cast_date))]);
+    } // Normalize option `columns`
+
+
+    var fnFirstLineToHeaders = null;
+
+    if (options.columns === true) {
+      // Fields in the first line are converted as-is to columns
+      fnFirstLineToHeaders = undefined;
+    } else if (typeof options.columns === 'function') {
+      fnFirstLineToHeaders = options.columns;
+      options.columns = true;
+    } else if (Array.isArray(options.columns)) {
+      options.columns = normalizeColumnsArray(options.columns);
+    } else if (options.columns === undefined || options.columns === null || options.columns === false) {
+      options.columns = false;
+    } else {
+      throw new CsvError('CSV_INVALID_OPTION_COLUMNS', ['Invalid option columns:', 'expect an object, a function or true,', "got ".concat(JSON.stringify(options.columns))]);
+    } // Normalize option `comment`
+
+
+    if (options.comment === undefined || options.comment === null || options.comment === false || options.comment === '') {
+      options.comment = null;
+    } else {
+      if (typeof options.comment === 'string') {
+        options.comment = Buffer.from(options.comment);
+      }
+
+      if (!Buffer.isBuffer(options.comment)) {
+        throw new CsvError('CSV_INVALID_OPTION_COMMENT', ['Invalid option comment:', 'comment must be a buffer or a string,', "got ".concat(JSON.stringify(options.comment))]);
+      }
+    } // Normalize option `delimiter`
+
+
+    if (options.delimiter === undefined || options.delimiter === null || options.delimiter === false) {
+      options.delimiter = Buffer.from(',');
+    } else if (typeof options.delimiter === 'string' && options.delimiter.length !== 0) {
+      options.delimiter = Buffer.from(options.delimiter);
+    } else if (Buffer.isBuffer(options.delimiter) && options.delimiter.length === 0 || typeof options.delimiter === 'string' && options.delimiter.length === 0 || !Buffer.isBuffer(options.delimiter) && typeof options.delimiter !== 'string') {
+      throw new CsvError('CSV_INVALID_OPTION_DELIMITER', ['Invalid option delimiter:', 'delimiter must be a non empty string or buffer,', "got ".concat(JSON.stringify(options.delimiter))]);
+    } // Normalize option `escape`
+
+
+    if (options.escape === undefined || options.escape === null) {
+      options.escape = Buffer.from('"');
+    } else if (typeof options.escape === 'string') {
+      options.escape = Buffer.from(options.escape);
+    }
+
+    if (!Buffer.isBuffer(options.escape)) {
+      throw new Error("Invalid Option: escape must be a buffer or a string, got ".concat(JSON.stringify(options.escape)));
+    } else if (options.escape.length !== 1) {
+      throw new Error("Invalid Option Length: escape must be one character, got ".concat(options.escape.length));
+    } else {
+      options.escape = options.escape[0];
+    } // Normalize option `from`
+
+
+    if (options.from === undefined || options.from === null) {
+      options.from = 1;
+    } else {
+      if (typeof options.from === 'string' && /\d+/.test(options.from)) {
+        options.from = parseInt(options.from);
+      }
+
+      if (Number.isInteger(options.from)) {
+        if (options.from < 0) {
+          throw new Error("Invalid Option: from must be a positive integer, got ".concat(JSON.stringify(opts.from)));
+        }
+      } else {
+        throw new Error("Invalid Option: from must be an integer, got ".concat(JSON.stringify(options.from)));
+      }
+    } // Normalize option `from_line`
+
+
+    if (options.from_line === undefined || options.from_line === null) {
+      options.from_line = 1;
+    } else {
+      if (typeof options.from_line === 'string' && /\d+/.test(options.from_line)) {
+        options.from_line = parseInt(options.from_line);
+      }
+
+      if (Number.isInteger(options.from_line)) {
+        if (options.from_line <= 0) {
+          throw new Error("Invalid Option: from_line must be a positive integer greater than 0, got ".concat(JSON.stringify(opts.from_line)));
+        }
+      } else {
+        throw new Error("Invalid Option: from_line must be an integer, got ".concat(JSON.stringify(opts.from_line)));
+      }
+    } // Normalize option `info`
+
+
+    if (options.info === undefined || options.info === null || options.info === false) {
+      options.info = false;
+    } else if (options.info !== true) {
+      throw new Error("Invalid Option: info must be true, got ".concat(JSON.stringify(options.info)));
+    } // Normalize option `max_record_size`
+
+
+    if (options.max_record_size === undefined || options.max_record_size === null || options.max_record_size === false) {
+      options.max_record_size = 0;
+    } else if (Number.isInteger(options.max_record_size) && options.max_record_size >= 0) {// Great, nothing to do
+    } else if (typeof options.max_record_size === 'string' && /\d+/.test(options.max_record_size)) {
+      options.max_record_size = parseInt(options.max_record_size);
+    } else {
+      throw new Error("Invalid Option: max_record_size must be a positive integer, got ".concat(JSON.stringify(options.max_record_size)));
+    } // Normalize option `objname`
+
+
+    if (options.objname === undefined || options.objname === null || options.objname === false) {
+      options.objname = undefined;
+    } else if (Buffer.isBuffer(options.objname)) {
+      if (options.objname.length === 0) {
+        throw new Error("Invalid Option: objname must be a non empty buffer");
+      }
+
+      options.objname = options.objname.toString();
+    } else if (typeof options.objname === 'string') {
+      if (options.objname.length === 0) {
+        throw new Error("Invalid Option: objname must be a non empty string");
+      } // Great, nothing to do
+
+    } else {
+      throw new Error("Invalid Option: objname must be a string or a buffer, got ".concat(options.objname));
+    } // Normalize option `on_record`
+
+
+    if (options.on_record === undefined || options.on_record === null) {
+      options.on_record = undefined;
+    } else if (typeof options.on_record !== 'function') {
+      throw new CsvError('CSV_INVALID_OPTION_ON_RECORD', ['Invalid option `on_record`:', 'expect a function,', "got ".concat(JSON.stringify(options.on_record))]);
+    } // Normalize option `quote`
+
+
+    if (options.quote === null || options.quote === false || options.quote === '') {
+      options.quote = null;
+    } else {
+      if (options.quote === undefined || options.quote === true) {
+        options.quote = Buffer.from('"');
+      } else if (typeof options.quote === 'string') {
+        options.quote = Buffer.from(options.quote);
+      }
+
+      if (!Buffer.isBuffer(options.quote)) {
+        throw new Error("Invalid Option: quote must be a buffer or a string, got ".concat(JSON.stringify(options.quote)));
+      } else if (options.quote.length !== 1) {
+        throw new Error("Invalid Option Length: quote must be one character, got ".concat(options.quote.length));
+      } else {
+        options.quote = options.quote[0];
+      }
+    } // Normalize option `raw`
+
+
+    if (options.raw === undefined || options.raw === null || options.raw === false) {
+      options.raw = false;
+    } else if (options.raw !== true) {
+      throw new Error("Invalid Option: raw must be true, got ".concat(JSON.stringify(options.raw)));
+    } // Normalize option `record_delimiter`
+
+
+    if (!options.record_delimiter) {
+      options.record_delimiter = [];
+    } else if (!Array.isArray(options.record_delimiter)) {
+      options.record_delimiter = [options.record_delimiter];
+    }
+
+    options.record_delimiter = options.record_delimiter.map(function (rd) {
+      if (typeof rd === 'string') {
+        rd = Buffer.from(rd);
+      }
+
+      return rd;
+    }); // Normalize option `relax`
+
+    if (typeof options.relax === 'boolean') {// Great, nothing to do
+    } else if (options.relax === undefined || options.relax === null) {
+      options.relax = false;
+    } else {
+      throw new Error("Invalid Option: relax must be a boolean, got ".concat(JSON.stringify(options.relax)));
+    } // Normalize option `relax_column_count`
+
+
+    if (typeof options.relax_column_count === 'boolean') {// Great, nothing to do
+    } else if (options.relax_column_count === undefined || options.relax_column_count === null) {
+      options.relax_column_count = false;
+    } else {
+      throw new Error("Invalid Option: relax_column_count must be a boolean, got ".concat(JSON.stringify(options.relax_column_count)));
+    }
+
+    if (typeof options.relax_column_count_less === 'boolean') {// Great, nothing to do
+    } else if (options.relax_column_count_less === undefined || options.relax_column_count_less === null) {
+      options.relax_column_count_less = false;
+    } else {
+      throw new Error("Invalid Option: relax_column_count_less must be a boolean, got ".concat(JSON.stringify(options.relax_column_count_less)));
+    }
+
+    if (typeof options.relax_column_count_more === 'boolean') {// Great, nothing to do
+    } else if (options.relax_column_count_more === undefined || options.relax_column_count_more === null) {
+      options.relax_column_count_more = false;
+    } else {
+      throw new Error("Invalid Option: relax_column_count_more must be a boolean, got ".concat(JSON.stringify(options.relax_column_count_more)));
+    } // Normalize option `skip_empty_lines`
+
+
+    if (typeof options.skip_empty_lines === 'boolean') {// Great, nothing to do
+    } else if (options.skip_empty_lines === undefined || options.skip_empty_lines === null) {
+      options.skip_empty_lines = false;
+    } else {
+      throw new Error("Invalid Option: skip_empty_lines must be a boolean, got ".concat(JSON.stringify(options.skip_empty_lines)));
+    } // Normalize option `skip_lines_with_empty_values`
+
+
+    if (typeof options.skip_lines_with_empty_values === 'boolean') {// Great, nothing to do
+    } else if (options.skip_lines_with_empty_values === undefined || options.skip_lines_with_empty_values === null) {
+      options.skip_lines_with_empty_values = false;
+    } else {
+      throw new Error("Invalid Option: skip_lines_with_empty_values must be a boolean, got ".concat(JSON.stringify(options.skip_lines_with_empty_values)));
+    } // Normalize option `skip_lines_with_error`
+
+
+    if (typeof options.skip_lines_with_error === 'boolean') {// Great, nothing to do
+    } else if (options.skip_lines_with_error === undefined || options.skip_lines_with_error === null) {
+      options.skip_lines_with_error = false;
+    } else {
+      throw new Error("Invalid Option: skip_lines_with_error must be a boolean, got ".concat(JSON.stringify(options.skip_lines_with_error)));
+    } // Normalize option `rtrim`
+
+
+    if (options.rtrim === undefined || options.rtrim === null || options.rtrim === false) {
+      options.rtrim = false;
+    } else if (options.rtrim !== true) {
+      throw new Error("Invalid Option: rtrim must be a boolean, got ".concat(JSON.stringify(options.rtrim)));
+    } // Normalize option `ltrim`
+
+
+    if (options.ltrim === undefined || options.ltrim === null || options.ltrim === false) {
+      options.ltrim = false;
+    } else if (options.ltrim !== true) {
+      throw new Error("Invalid Option: ltrim must be a boolean, got ".concat(JSON.stringify(options.ltrim)));
+    } // Normalize option `trim`
+
+
+    if (options.trim === undefined || options.trim === null || options.trim === false) {
+      options.trim = false;
+    } else if (options.trim !== true) {
+      throw new Error("Invalid Option: trim must be a boolean, got ".concat(JSON.stringify(options.trim)));
+    } // Normalize options `trim`, `ltrim` and `rtrim`
+
+
+    if (options.trim === true && opts.ltrim !== false) {
+      options.ltrim = true;
+    } else if (options.ltrim !== true) {
+      options.ltrim = false;
+    }
+
+    if (options.trim === true && opts.rtrim !== false) {
+      options.rtrim = true;
+    } else if (options.rtrim !== true) {
+      options.rtrim = false;
+    } // Normalize option `to`
+
+
+    if (options.to === undefined || options.to === null) {
+      options.to = -1;
+    } else {
+      if (typeof options.to === 'string' && /\d+/.test(options.to)) {
+        options.to = parseInt(options.to);
+      }
+
+      if (Number.isInteger(options.to)) {
+        if (options.to <= 0) {
+          throw new Error("Invalid Option: to must be a positive integer greater than 0, got ".concat(JSON.stringify(opts.to)));
+        }
+      } else {
+        throw new Error("Invalid Option: to must be an integer, got ".concat(JSON.stringify(opts.to)));
+      }
+    } // Normalize option `to_line`
+
+
+    if (options.to_line === undefined || options.to_line === null) {
+      options.to_line = -1;
+    } else {
+      if (typeof options.to_line === 'string' && /\d+/.test(options.to_line)) {
+        options.to_line = parseInt(options.to_line);
+      }
+
+      if (Number.isInteger(options.to_line)) {
+        if (options.to_line <= 0) {
+          throw new Error("Invalid Option: to_line must be a positive integer greater than 0, got ".concat(JSON.stringify(opts.to_line)));
+        }
+      } else {
+        throw new Error("Invalid Option: to_line must be an integer, got ".concat(JSON.stringify(opts.to_line)));
+      }
+    }
+
+    _this.info = {
+      comment_lines: 0,
+      empty_lines: 0,
+      invalid_field_length: 0,
+      lines: 1,
+      records: 0
+    };
+    _this.options = options;
+    _this.state = {
+      bomSkipped: false,
+      castField: fnCastField,
+      commenting: false,
+      enabled: options.from_line === 1,
+      escaping: false,
+      escapeIsQuote: options.escape === options.quote,
+      expectedRecordLength: options.columns === null ? 0 : options.columns.length,
+      field: new ResizeableBuffer(20),
+      firstLineToHeaders: fnFirstLineToHeaders,
+      info: Object.assign({}, _this.info),
+      previousBuf: undefined,
+      quoting: false,
+      stop: false,
+      rawBuffer: new ResizeableBuffer(100),
+      record: [],
+      recordHasError: false,
+      record_length: 0,
+      recordDelimiterMaxLength: options.record_delimiter.length === 0 ? 2 : Math.max.apply(Math, _toConsumableArray(options.record_delimiter.map(function (v) {
+        return v.length;
+      }))),
+      trimChars: [Buffer.from(' ')[0], Buffer.from('\t')[0]],
+      wasQuoting: false,
+      wasRowDelimiter: false
+    };
+    return _this;
+  } // Implementation of `Transform._transform`
+
+
+  _createClass(Parser, [{
+    key: "_transform",
+    value: function _transform(buf, encoding, callback) {
+      if (this.state.stop === true) {
+        return;
+      }
+
+      var err = this.__parse(buf, false);
+
+      if (err !== undefined) {
+        this.state.stop = true;
+      }
+
+      callback(err);
+    } // Implementation of `Transform._flush`
+
+  }, {
+    key: "_flush",
+    value: function _flush(callback) {
+      if (this.state.stop === true) {
+        return;
+      }
+
+      var err = this.__parse(undefined, true);
+
+      callback(err);
+    } // Central parser implementation
+
+  }, {
+    key: "__parse",
+    value: function __parse(nextBuf, end) {
+      var _this$options = this.options,
+          bom = _this$options.bom,
+          comment = _this$options.comment,
+          escape = _this$options.escape,
+          from_line = _this$options.from_line,
+          info = _this$options.info,
+          ltrim = _this$options.ltrim,
+          max_record_size = _this$options.max_record_size,
+          quote = _this$options.quote,
+          raw = _this$options.raw,
+          relax = _this$options.relax,
+          rtrim = _this$options.rtrim,
+          skip_empty_lines = _this$options.skip_empty_lines,
+          to = _this$options.to,
+          to_line = _this$options.to_line;
+      var record_delimiter = this.options.record_delimiter;
+      var _this$state = this.state,
+          bomSkipped = _this$state.bomSkipped,
+          previousBuf = _this$state.previousBuf,
+          rawBuffer = _this$state.rawBuffer,
+          escapeIsQuote = _this$state.escapeIsQuote;
+      var buf;
+
+      if (previousBuf === undefined) {
+        if (nextBuf === undefined) {
+          // Handle empty string
+          this.push(null);
+          return;
+        } else {
+          buf = nextBuf;
+        }
+      } else if (previousBuf !== undefined && nextBuf === undefined) {
+        buf = previousBuf;
+      } else {
+        buf = Buffer.concat([previousBuf, nextBuf]);
+      } // Handle UTF BOM
+
+
+      if (bomSkipped === false) {
+        if (bom === false) {
+          this.state.bomSkipped = true;
+        } else if (buf.length < 3) {
+          // No enough data
+          if (end === false) {
+            // Wait for more data
+            this.state.previousBuf = buf;
+            return;
+          } // skip BOM detect because data length < 3
+
+        } else {
+          if (bom_utf8.compare(buf, 0, 3) === 0) {
+            // Skip BOM
+            buf = buf.slice(3);
+          }
+
+          this.state.bomSkipped = true;
+        }
+      }
+
+      var bufLen = buf.length;
+      var pos;
+
+      for (pos = 0; pos < bufLen; pos++) {
+        // Ensure we get enough space to look ahead
+        // There should be a way to move this out of the loop
+        if (this.__needMoreData(pos, bufLen, end)) {
+          break;
+        }
+
+        if (this.state.wasRowDelimiter === true) {
+          this.info.lines++;
+
+          if (info === true && this.state.record.length === 0 && this.state.field.length === 0 && this.state.wasQuoting === false) {
+            this.state.info = Object.assign({}, this.info);
+          }
+
+          this.state.wasRowDelimiter = false;
+        }
+
+        if (to_line !== -1 && this.info.lines > to_line) {
+          this.state.stop = true;
+          this.push(null);
+          return;
+        } // Auto discovery of record_delimiter, unix, mac and windows supported
+
+
+        if (this.state.quoting === false && record_delimiter.length === 0) {
+          var record_delimiterCount = this.__autoDiscoverRowDelimiter(buf, pos);
+
+          if (record_delimiterCount) {
+            record_delimiter = this.options.record_delimiter;
+          }
+        }
+
+        var chr = buf[pos];
+
+        if (raw === true) {
+          rawBuffer.append(chr);
+        }
+
+        if ((chr === cr || chr === nl) && this.state.wasRowDelimiter === false) {
+          this.state.wasRowDelimiter = true;
+        } // Previous char was a valid escape char
+        // treat the current char as a regular char
+
+
+        if (this.state.escaping === true) {
+          this.state.escaping = false;
+        } else {
+          // Escape is only active inside quoted fields
+          // We are quoting, the char is an escape chr and there is a chr to escape
+          if (this.state.quoting === true && chr === escape && pos + 1 < bufLen) {
+            if (escapeIsQuote) {
+              if (buf[pos + 1] === quote) {
+                this.state.escaping = true;
+                continue;
+              }
+            } else {
+              this.state.escaping = true;
+              continue;
+            }
+          } // Not currently escaping and chr is a quote
+          // TODO: need to compare bytes instead of single char
+
+
+          if (this.state.commenting === false && chr === quote) {
+            if (this.state.quoting === true) {
+              var nextChr = buf[pos + 1];
+
+              var isNextChrTrimable = rtrim && this.__isCharTrimable(nextChr); // const isNextChrComment = nextChr === comment
+
+
+              var isNextChrComment = comment !== null && this.__compareBytes(comment, buf, pos + 1, nextChr);
+
+              var isNextChrDelimiter = this.__isDelimiter(nextChr, buf, pos + 1);
+
+              var isNextChrRowDelimiter = record_delimiter.length === 0 ? this.__autoDiscoverRowDelimiter(buf, pos + 1) : this.__isRecordDelimiter(nextChr, buf, pos + 1); // Escape a quote
+              // Treat next char as a regular character
+              // TODO: need to compare bytes instead of single char
+
+              if (chr === escape && nextChr === quote) {
+                pos++;
+              } else if (!nextChr || isNextChrDelimiter || isNextChrRowDelimiter || isNextChrComment || isNextChrTrimable) {
+                this.state.quoting = false;
+                this.state.wasQuoting = true;
+                continue;
+              } else if (relax === false) {
+                var err = this.__error(new CsvError('CSV_INVALID_CLOSING_QUOTE', ['Invalid Closing Quote:', "got \"".concat(String.fromCharCode(nextChr), "\""), "at line ".concat(this.info.lines), 'instead of delimiter, row delimiter, trimable character', '(if activated) or comment'], this.__context()));
+
+                if (err !== undefined) return err;
+              } else {
+                this.state.quoting = false;
+                this.state.wasQuoting = true; // continue
+
+                this.state.field.prepend(quote);
+              }
+            } else {
+              if (this.state.field.length !== 0) {
+                // In relax mode, treat opening quote preceded by chrs as regular
+                if (relax === false) {
+                  var _err = this.__error(new CsvError('INVALID_OPENING_QUOTE', ['Invalid Opening Quote:', "a quote is found inside a field at line ".concat(this.info.lines)], this.__context(), {
+                    field: this.state.field
+                  }));
+
+                  if (_err !== undefined) return _err;
+                }
+              } else {
+                this.state.quoting = true;
+                continue;
+              }
+            }
+          }
+
+          if (this.state.quoting === false) {
+            var recordDelimiterLength = this.__isRecordDelimiter(chr, buf, pos);
+
+            if (recordDelimiterLength !== 0) {
+              // Do not emit comments which take a full line
+              var skipCommentLine = this.state.commenting && this.state.wasQuoting === false && this.state.record.length === 0 && this.state.field.length === 0;
+
+              if (skipCommentLine) {
+                this.info.comment_lines++; // Skip full comment line
+              } else {
+                // Skip if line is empty and skip_empty_lines activated
+                if (skip_empty_lines === true && this.state.wasQuoting === false && this.state.record.length === 0 && this.state.field.length === 0) {
+                  this.info.empty_lines++;
+                  pos += recordDelimiterLength - 1;
+                  continue;
+                } // Activate records emition if above from_line
+
+
+                if (this.state.enabled === false && this.info.lines + (this.state.wasRowDelimiter === true ? 1 : 0) >= from_line) {
+                  this.state.enabled = true;
+
+                  this.__resetField();
+
+                  this.__resetRow();
+
+                  pos += recordDelimiterLength - 1;
+                  continue;
+                } else {
+                  var errField = this.__onField();
+
+                  if (errField !== undefined) return errField;
+
+                  var errRecord = this.__onRow();
+
+                  if (errRecord !== undefined) return errRecord;
+                }
+
+                if (to !== -1 && this.info.records >= to) {
+                  this.state.stop = true;
+                  this.push(null);
+                  return;
+                }
+              }
+
+              this.state.commenting = false;
+              pos += recordDelimiterLength - 1;
+              continue;
+            }
+
+            if (this.state.commenting) {
+              continue;
+            }
+
+            var commentCount = comment === null ? 0 : this.__compareBytes(comment, buf, pos, chr);
+
+            if (commentCount !== 0) {
+              this.state.commenting = true;
+              continue;
+            }
+
+            var delimiterLength = this.__isDelimiter(chr, buf, pos);
+
+            if (delimiterLength !== 0) {
+              var _errField = this.__onField();
+
+              if (_errField !== undefined) return _errField;
+              pos += delimiterLength - 1;
+              continue;
+            }
+          }
+        }
+
+        if (this.state.commenting === false) {
+          if (max_record_size !== 0 && this.state.record_length + this.state.field.length > max_record_size) {
+            var _err2 = this.__error(new CsvError('CSV_MAX_RECORD_SIZE', ['Max Record Size:', 'record exceed the maximum number of tolerated bytes', "of ".concat(max_record_size), "at line ".concat(this.info.lines)], this.__context()));
+
+            if (_err2 !== undefined) return _err2;
+          }
+        }
+
+        var lappend = ltrim === false || this.state.quoting === true || this.state.field.length !== 0 || !this.__isCharTrimable(chr); // rtrim in non quoting is handle in __onField
+
+        var rappend = rtrim === false || this.state.wasQuoting === false;
+
+        if (lappend === true && rappend === true) {
+          this.state.field.append(chr);
+        } else if (rtrim === true && !this.__isCharTrimable(chr)) {
+          var _err3 = this.__error(new CsvError('CSV_NON_TRIMABLE_CHAR_AFTER_CLOSING_QUOTE', ['Invalid Closing Quote:', 'found non trimable byte after quote', "at line ".concat(this.info.lines)], this.__context()));
+
+          if (_err3 !== undefined) return _err3;
+        }
+      }
+
+      if (end === true) {
+        // Ensure we are not ending in a quoting state
+        if (this.state.quoting === true) {
+          var _err4 = this.__error(new CsvError('CSV_QUOTE_NOT_CLOSED', ['Quote Not Closed:', "the parsing is finished with an opening quote at line ".concat(this.info.lines)], this.__context()));
+
+          if (_err4 !== undefined) return _err4;
+        } else {
+          // Skip last line if it has no characters
+          if (this.state.wasQuoting === true || this.state.record.length !== 0 || this.state.field.length !== 0) {
+            var _errField2 = this.__onField();
+
+            if (_errField2 !== undefined) return _errField2;
+
+            var _errRecord = this.__onRow();
+
+            if (_errRecord !== undefined) return _errRecord;
+          } else if (this.state.wasRowDelimiter === true) {
+            this.info.empty_lines++;
+          } else if (this.state.commenting === true) {
+            this.info.comment_lines++;
+          }
+        }
+      } else {
+        this.state.previousBuf = buf.slice(pos);
+      }
+
+      if (this.state.wasRowDelimiter === true) {
+        this.info.lines++;
+        this.state.wasRowDelimiter = false;
+      }
+    } // Helper to test if a character is a space or a line delimiter
+
+  }, {
+    key: "__isCharTrimable",
+    value: function __isCharTrimable(chr) {
+      return chr === space || chr === tab || chr === cr || chr === nl || chr === np;
+    }
+  }, {
+    key: "__onRow",
+    value: function __onRow() {
+      var _this$options2 = this.options,
+          columns = _this$options2.columns,
+          info = _this$options2.info,
+          from = _this$options2.from,
+          relax_column_count = _this$options2.relax_column_count,
+          relax_column_count_less = _this$options2.relax_column_count_less,
+          relax_column_count_more = _this$options2.relax_column_count_more,
+          raw = _this$options2.raw,
+          skip_lines_with_empty_values = _this$options2.skip_lines_with_empty_values;
+      var _this$state2 = this.state,
+          enabled = _this$state2.enabled,
+          record = _this$state2.record;
+
+      if (enabled === false) {
+        return this.__resetRow();
+      } // Convert the first line into column names
+
+
+      var recordLength = record.length;
+
+      if (columns === true) {
+        if (isRecordEmpty(record)) {
+          this.__resetRow();
+
+          return;
+        }
+
+        return this.__firstLineToColumns(record);
+      }
+
+      if (columns === false && this.info.records === 0) {
+        this.state.expectedRecordLength = recordLength;
+      }
+
+      if (recordLength !== this.state.expectedRecordLength) {
+        if (relax_column_count === true || relax_column_count_less === true && recordLength < this.state.expectedRecordLength || relax_column_count_more === true && recordLength > this.state.expectedRecordLength) {
+          this.info.invalid_field_length++;
+        } else {
+          if (columns === false) {
+            var err = this.__error(new CsvError('CSV_INCONSISTENT_RECORD_LENGTH', ['Invalid Record Length:', "expect ".concat(this.state.expectedRecordLength, ","), "got ".concat(recordLength, " on line ").concat(this.info.lines)], this.__context(), {
+              record: record
+            }));
+
+            if (err !== undefined) return err;
+          } else {
+            var _err5 = this.__error( // CSV_INVALID_RECORD_LENGTH_DONT_MATCH_COLUMNS
+            new CsvError('CSV_RECORD_DONT_MATCH_COLUMNS_LENGTH', ['Invalid Record Length:', "columns length is ".concat(columns.length, ","), // rename columns
+            "got ".concat(recordLength, " on line ").concat(this.info.lines)], this.__context(), {
+              record: record
+            }));
+
+            if (_err5 !== undefined) return _err5;
+          }
+        }
+      }
+
+      if (skip_lines_with_empty_values === true) {
+        if (isRecordEmpty(record)) {
+          this.__resetRow();
+
+          return;
+        }
+      }
+
+      if (this.state.recordHasError === true) {
+        this.__resetRow();
+
+        this.state.recordHasError = false;
+        return;
+      }
+
+      this.info.records++;
+
+      if (from === 1 || this.info.records >= from) {
+        if (columns !== false) {
+          var obj = {}; // Transform record array to an object
+
+          for (var i = 0, l = record.length; i < l; i++) {
+            if (columns[i] === undefined || columns[i].disabled) continue;
+            obj[columns[i].name] = record[i];
+          }
+
+          var objname = this.options.objname;
+
+          if (objname === undefined) {
+            if (raw === true || info === true) {
+              var _err6 = this.__push(Object.assign({
+                record: obj
+              }, raw === true ? {
+                raw: this.state.rawBuffer.toString()
+              } : {}, info === true ? {
+                info: this.state.info
+              } : {}));
+
+              if (_err6) {
+                return _err6;
+              }
+            } else {
+              var _err7 = this.__push(obj);
+
+              if (_err7) {
+                return _err7;
+              }
+            }
+          } else {
+            if (raw === true || info === true) {
+              var _err8 = this.__push(Object.assign({
+                record: [obj[objname], obj]
+              }, raw === true ? {
+                raw: this.state.rawBuffer.toString()
+              } : {}, info === true ? {
+                info: this.state.info
+              } : {}));
+
+              if (_err8) {
+                return _err8;
+              }
+            } else {
+              var _err9 = this.__push([obj[objname], obj]);
+
+              if (_err9) {
+                return _err9;
+              }
+            }
+          }
+        } else {
+          if (raw === true || info === true) {
+            var _err10 = this.__push(Object.assign({
+              record: record
+            }, raw === true ? {
+              raw: this.state.rawBuffer.toString()
+            } : {}, info === true ? {
+              info: this.state.info
+            } : {}));
+
+            if (_err10) {
+              return _err10;
+            }
+          } else {
+            var _err11 = this.__push(record);
+
+            if (_err11) {
+              return _err11;
+            }
+          }
+        }
+      }
+
+      this.__resetRow();
+    }
+  }, {
+    key: "__firstLineToColumns",
+    value: function __firstLineToColumns(record) {
+      var firstLineToHeaders = this.state.firstLineToHeaders;
+
+      try {
+        var headers = firstLineToHeaders === undefined ? record : firstLineToHeaders.call(null, record);
+
+        if (!Array.isArray(headers)) {
+          return this.__error(new CsvError('CSV_INVALID_COLUMN_MAPPING', ['Invalid Column Mapping:', 'expect an array from column function,', "got ".concat(JSON.stringify(headers))], this.__context(), {
+            headers: headers
+          }));
+        }
+
+        var normalizedHeaders = normalizeColumnsArray(headers);
+        this.state.expectedRecordLength = normalizedHeaders.length;
+        this.options.columns = normalizedHeaders;
+
+        this.__resetRow();
+
+        return;
+      } catch (err) {
+        return err;
+      }
+    }
+  }, {
+    key: "__resetRow",
+    value: function __resetRow() {
+      if (this.options.raw === true) {
+        this.state.rawBuffer.reset();
+      }
+
+      this.state.record = [];
+      this.state.record_length = 0;
+    }
+  }, {
+    key: "__onField",
+    value: function __onField() {
+      var _this$options3 = this.options,
+          cast = _this$options3.cast,
+          rtrim = _this$options3.rtrim,
+          max_record_size = _this$options3.max_record_size;
+      var _this$state3 = this.state,
+          enabled = _this$state3.enabled,
+          wasQuoting = _this$state3.wasQuoting; // Short circuit for the from_line options
+
+      if (enabled === false) {
+        /* this.options.columns !== true && */
+        return this.__resetField();
+      }
+
+      var field = this.state.field.toString();
+
+      if (rtrim === true && wasQuoting === false) {
+        field = field.trimRight();
+      }
+
+      if (cast === true) {
+        var _this$__cast = this.__cast(field),
+            _this$__cast2 = _slicedToArray(_this$__cast, 2),
+            err = _this$__cast2[0],
+            f = _this$__cast2[1];
+
+        if (err !== undefined) return err;
+        field = f;
+      }
+
+      this.state.record.push(field); // Increment record length if record size must not exceed a limit
+
+      if (max_record_size !== 0 && typeof field === 'string') {
+        this.state.record_length += field.length;
+      }
+
+      this.__resetField();
+    }
+  }, {
+    key: "__resetField",
+    value: function __resetField() {
+      this.state.field.reset();
+      this.state.wasQuoting = false;
+    }
+  }, {
+    key: "__push",
+    value: function __push(record) {
+      var on_record = this.options.on_record;
+
+      if (on_record !== undefined) {
+        var context = this.__context();
+
+        try {
+          record = on_record.call(null, record, context);
+        } catch (err) {
+          return err;
+        }
+
+        if (record === undefined || record === null) {
+          return;
+        }
+      }
+
+      this.push(record);
+    } // Return a tuple with the error and the casted value
+
+  }, {
+    key: "__cast",
+    value: function __cast(field) {
+      var _this$options4 = this.options,
+          columns = _this$options4.columns,
+          relax_column_count = _this$options4.relax_column_count;
+      var isColumns = Array.isArray(columns); // Dont loose time calling cast
+      // because the final record is an object
+      // and this field can't be associated to a key present in columns
+
+      if (isColumns === true && relax_column_count && this.options.columns.length <= this.state.record.length) {
+        return [undefined, undefined];
+      }
+
+      var context = this.__context();
+
+      if (this.state.castField !== null) {
+        try {
+          return [undefined, this.state.castField.call(null, field, context)];
+        } catch (err) {
+          return [err];
+        }
+      }
+
+      if (this.__isFloat(field)) {
+        return [undefined, parseFloat(field)];
+      } else if (this.options.cast_date !== false) {
+        return [undefined, this.options.cast_date.call(null, field, context)];
+      }
+
+      return [undefined, field];
+    } // Keep it in case we implement the `cast_int` option
+    // __isInt(value){
+    //   // return Number.isInteger(parseInt(value))
+    //   // return !isNaN( parseInt( obj ) );
+    //   return /^(\-|\+)?[1-9][0-9]*$/.test(value)
+    // }
+
+  }, {
+    key: "__isFloat",
+    value: function __isFloat(value) {
+      return value - parseFloat(value) + 1 >= 0; // Borrowed from jquery
+    }
+  }, {
+    key: "__compareBytes",
+    value: function __compareBytes(sourceBuf, targetBuf, pos, firtByte) {
+      if (sourceBuf[0] !== firtByte) return 0;
+      var sourceLength = sourceBuf.length;
+
+      for (var i = 1; i < sourceLength; i++) {
+        if (sourceBuf[i] !== targetBuf[pos + i]) return 0;
+      }
+
+      return sourceLength;
+    }
+  }, {
+    key: "__needMoreData",
+    value: function __needMoreData(i, bufLen, end) {
+      if (end) {
+        return false;
+      }
+
+      var _this$options5 = this.options,
+          comment = _this$options5.comment,
+          delimiter = _this$options5.delimiter;
+      var _this$state4 = this.state,
+          quoting = _this$state4.quoting,
+          recordDelimiterMaxLength = _this$state4.recordDelimiterMaxLength;
+      var numOfCharLeft = bufLen - i - 1;
+      var requiredLength = Math.max( // Skip if the remaining buffer smaller than comment
+      comment ? comment.length : 0, // Skip if the remaining buffer smaller than row delimiter
+      recordDelimiterMaxLength, // Skip if the remaining buffer can be row delimiter following the closing quote
+      // 1 is for quote.length
+      quoting ? 1 + recordDelimiterMaxLength : 0, // Skip if the remaining buffer can be delimiter
+      delimiter.length, // Skip if the remaining buffer can be escape sequence
+      // 1 is for escape.length
+      1);
+      return numOfCharLeft < requiredLength;
+    }
+  }, {
+    key: "__isDelimiter",
+    value: function __isDelimiter(chr, buf, pos) {
+      var delimiter = this.options.delimiter;
+      var delLength = delimiter.length;
+      if (delimiter[0] !== chr) return 0;
+
+      for (var i = 1; i < delLength; i++) {
+        if (delimiter[i] !== buf[pos + i]) return 0;
+      }
+
+      return delimiter.length;
+    }
+  }, {
+    key: "__isRecordDelimiter",
+    value: function __isRecordDelimiter(chr, buf, pos) {
+      var record_delimiter = this.options.record_delimiter;
+      var recordDelimiterLength = record_delimiter.length;
+
+      loop1: for (var i = 0; i < recordDelimiterLength; i++) {
+        var rd = record_delimiter[i];
+        var rdLength = rd.length;
+
+        if (rd[0] !== chr) {
+          continue;
+        }
+
+        for (var j = 1; j < rdLength; j++) {
+          if (rd[j] !== buf[pos + j]) {
+            continue loop1;
+          }
+        }
+
+        return rd.length;
+      }
+
+      return 0;
+    }
+  }, {
+    key: "__autoDiscoverRowDelimiter",
+    value: function __autoDiscoverRowDelimiter(buf, pos) {
+      var chr = buf[pos];
+
+      if (chr === cr) {
+        if (buf[pos + 1] === nl) {
+          this.options.record_delimiter.push(Buffer.from('\r\n'));
+          this.state.recordDelimiterMaxLength = 2;
+          return 2;
+        } else {
+          this.options.record_delimiter.push(Buffer.from('\r'));
+          this.state.recordDelimiterMaxLength = 1;
+          return 1;
+        }
+      } else if (chr === nl) {
+        this.options.record_delimiter.push(Buffer.from('\n'));
+        this.state.recordDelimiterMaxLength = 1;
+        return 1;
+      }
+
+      return 0;
+    }
+  }, {
+    key: "__error",
+    value: function __error(msg) {
+      var skip_lines_with_error = this.options.skip_lines_with_error;
+      var err = typeof msg === 'string' ? new Error(msg) : msg;
+
+      if (skip_lines_with_error) {
+        this.state.recordHasError = true;
+        this.emit('skip', err);
+        return undefined;
+      } else {
+        return err;
+      }
+    }
+  }, {
+    key: "__context",
+    value: function __context() {
+      var columns = this.options.columns;
+      var isColumns = Array.isArray(columns);
+      return {
+        column: isColumns === true ? columns.length > this.state.record.length ? columns[this.state.record.length].name : null : this.state.record.length,
+        empty_lines: this.info.empty_lines,
+        header: columns === true,
+        index: this.state.record.length,
+        invalid_field_length: this.info.invalid_field_length,
+        quoting: this.state.wasQuoting,
+        lines: this.info.lines,
+        records: this.info.records
+      };
+    }
+  }]);
+
+  return Parser;
+}(Transform);
+
+var parse = function parse() {
+  var data, options, callback;
+
+  for (var i in arguments) {
+    var argument = arguments[i];
+
+    var type = _typeof(argument);
+
+    if (data === undefined && (typeof argument === 'string' || Buffer.isBuffer(argument))) {
+      data = argument;
+    } else if (options === undefined && isObject(argument)) {
+      options = argument;
+    } else if (callback === undefined && type === 'function') {
+      callback = argument;
+    } else {
+      throw new CsvError('CSV_INVALID_ARGUMENT', ['Invalid argument:', "got ".concat(JSON.stringify(argument), " at index ").concat(i)]);
+    }
+  }
+
+  var parser = new Parser(options);
+
+  if (callback) {
+    var records = options === undefined || options.objname === undefined ? [] : {};
+    parser.on('readable', function () {
+      var record;
+
+      while ((record = this.read()) !== null) {
+        if (options === undefined || options.objname === undefined) {
+          records.push(record);
+        } else {
+          records[record[0]] = record[1];
+        }
+      }
+    });
+    parser.on('error', function (err) {
+      callback(err, undefined, parser.info);
+    });
+    parser.on('end', function () {
+      callback(undefined, records, parser.info);
+    });
+  }
+
+  if (data !== undefined) {
+    // Give a chance for events to be registered later
+    if (typeof setImmediate === 'function') {
+      setImmediate(function () {
+        parser.write(data);
+        parser.end();
+      });
+    } else {
+      parser.write(data);
+      parser.end();
+    }
+  }
+
+  return parser;
+};
+
+var CsvError = /*#__PURE__*/function (_Error) {
+  _inherits(CsvError, _Error);
+
+  function CsvError(code, message) {
+    var _this2;
+
+    _classCallCheck(this, CsvError);
+
+    if (Array.isArray(message)) message = message.join(' ');
+    _this2 = _possibleConstructorReturn(this, _getPrototypeOf(CsvError).call(this, message));
+
+    if (Error.captureStackTrace !== undefined) {
+      Error.captureStackTrace(_assertThisInitialized(_this2), CsvError);
+    }
+
+    _this2.code = code;
+
+    for (var _len = arguments.length, contexts = new Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
+      contexts[_key - 2] = arguments[_key];
+    }
+
+    for (var _i2 = 0, _contexts = contexts; _i2 < _contexts.length; _i2++) {
+      var context = _contexts[_i2];
+
+      for (var key in context) {
+        var value = context[key];
+        _this2[key] = Buffer.isBuffer(value) ? value.toString() : value == null ? value : JSON.parse(JSON.stringify(value));
+      }
+    }
+
+    return _this2;
+  }
+
+  return CsvError;
+}( /*#__PURE__*/_wrapNativeSuper(Error));
+
+parse.Parser = Parser;
+parse.CsvError = CsvError;
+module.exports = parse;
+
+var underscore = function underscore(str) {
+  return str.replace(/([A-Z])/g, function (_, match) {
+    return '_' + match.toLowerCase();
+  });
+};
+
+var isObject = function isObject(obj) {
+  return _typeof(obj) === 'object' && obj !== null && !Array.isArray(obj);
+};
+
+var isRecordEmpty = function isRecordEmpty(record) {
+  return record.every(function (field) {
+    return field == null || field.toString && field.toString().trim() === '';
+  });
+};
+
+var normalizeColumnsArray = function normalizeColumnsArray(columns) {
+  var normalizedColumns = [];
+
+  for (var i = 0, l = columns.length; i < l; i++) {
+    var column = columns[i];
+
+    if (column === undefined || column === null || column === false) {
+      normalizedColumns[i] = {
+        disabled: true
+      };
+    } else if (typeof column === 'string') {
+      normalizedColumns[i] = {
+        name: column
+      };
+    } else if (isObject(column)) {
+      if (typeof column.name !== 'string') {
+        throw new CsvError('CSV_OPTION_COLUMNS_MISSING_NAME', ['Option columns missing name:', "property \"name\" is required at position ".concat(i), 'when column is an object literal']);
+      }
+
+      normalizedColumns[i] = column;
+    } else {
+      throw new CsvError('CSV_INVALID_COLUMN_DEFINITION', ['Invalid column definition:', 'expect a string or a literal object,', "got ".concat(JSON.stringify(column), " at position ").concat(i)]);
+    }
+  }
+
+  return normalizedColumns;
+};

--- a/node_modules/csv-parse/lib/es5/sync.d.ts
+++ b/node_modules/csv-parse/lib/es5/sync.d.ts
@@ -1,0 +1,6 @@
+import * as csvParse from './index';
+
+export = parse;
+
+declare function parse(input: Buffer | string, options?: csvParse.Options): any;
+declare namespace parse {}

--- a/node_modules/csv-parse/lib/es5/sync.js
+++ b/node_modules/csv-parse/lib/es5/sync.js
@@ -1,0 +1,33 @@
+"use strict";
+
+var parse = require('.');
+
+module.exports = function (data) {
+  var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+  if (typeof data === 'string') {
+    data = Buffer.from(data);
+  }
+
+  var records = options && options.objname ? {} : [];
+  var parser = new parse.Parser(options);
+
+  parser.push = function (record) {
+    if (record === null) {
+      return;
+    }
+
+    if (options.objname === undefined) records.push(record);else {
+      records[record[0]] = record[1];
+    }
+  };
+
+  var err1 = parser.__parse(data, false);
+
+  if (err1 !== undefined) throw err1;
+
+  var err2 = parser.__parse(undefined, true);
+
+  if (err2 !== undefined) throw err2;
+  return records;
+};

--- a/node_modules/csv-parse/lib/index.d.ts
+++ b/node_modules/csv-parse/lib/index.d.ts
@@ -1,0 +1,207 @@
+// Original definitions in https://github.com/DefinitelyTyped/DefinitelyTyped by: David Muller <https://github.com/davidm77>
+
+/// <reference types="node" />
+
+import * as stream from "stream";
+
+export = parse;
+
+declare function parse(input: Buffer | string, options?: parse.Options, callback?: parse.Callback): parse.Parser;
+declare function parse(input: Buffer | string, callback?: parse.Callback): parse.Parser;
+declare function parse(options?: parse.Options, callback?: parse.Callback): parse.Parser;
+declare function parse(callback?: parse.Callback): parse.Parser;
+declare namespace parse {
+
+    type Callback = (err: Error | undefined, records: any | undefined, info: Info) => void;
+
+    interface Parser extends stream.Transform {}
+
+    class Parser {
+        constructor(options: Options);
+        
+        __push(line: any): any;
+        
+        __write(chars: any, end: any, callback: any): any;
+        
+        readonly options: Options
+        
+        readonly info: Info;
+    }
+
+    interface CastingContext {
+        readonly column: number | string;
+        readonly empty_lines: number;
+        readonly header: boolean;
+        readonly index: number;
+        readonly quoting: boolean;
+        readonly lines: number;
+        readonly records: number;
+        readonly invalid_field_length: number;
+    }
+
+    type CastingFunction = (value: string, context: CastingContext) => any;
+
+    type CastingDateFunction = (value: string, context: CastingContext) => Date;
+
+    type ColumnOption = string | undefined | null | false | { name: string };
+
+    interface Options {
+        /**
+         * If true, the parser will attempt to convert read data types to native types.
+         * @deprecated Use {@link cast}
+         */
+        auto_parse?: boolean | CastingFunction;
+        /**
+         * If true, the parser will attempt to convert read data types to dates. It requires the "auto_parse" option.
+         * @deprecated Use {@link cast_date}
+         */
+        auto_parse_date?: boolean | CastingDateFunction;
+        /**
+         * If true, detect and exclude the byte order mark (BOM) from the CSV input if present.
+         */
+        bom?: boolean;
+        /**
+         * If true, the parser will attempt to convert input string to native types.
+         * If a function, receive the value as first argument, a context as second argument and return a new value. More information about the context properties is available below.
+         */
+        cast?: boolean | CastingFunction;
+        /**
+         * If true, the parser will attempt to convert input string to dates.
+         * If a function, receive the value as argument and return a new value. It requires the "auto_parse" option. Be careful, it relies on Date.parse.
+         */
+        cast_date?: boolean | CastingDateFunction;
+        /**
+         * List of fields as an array,
+         * a user defined callback accepting the first line and returning the column names or true if autodiscovered in the first CSV line,
+         * default to null,
+         * affect the result data set in the sense that records will be objects instead of arrays.
+         */
+        columns?: ColumnOption[] | boolean | ((record: any) => ColumnOption[]);
+        /**
+         * Treat all the characters after this one as a comment, default to '' (disabled).
+         */
+        comment?: string;
+        /**
+         * Set the field delimiter. One character only, defaults to comma.
+         */
+        delimiter?: string | Buffer;
+        /**
+         * Set the escape character, one character only, defaults to double quotes.
+         */
+        escape?: string | Buffer;
+        /**
+         * Start handling records from the requested number of records.
+         */
+        from?: number;
+        /**
+         * Start handling records from the requested line number.
+         */
+        from_line?: number;
+        /**
+         * Generate two properties `info` and `record` where `info` is a snapshot of the info object at the time the record was created and `record` is the parsed array or object.
+         */
+        info?: boolean;
+        /**
+         * If true, ignore whitespace immediately following the delimiter (i.e. left-trim all fields), defaults to false.
+         * Does not remove whitespace in a quoted field.
+         */
+        ltrim?: boolean;
+        /**
+         * Maximum numer of characters to be contained in the field and line buffers before an exception is raised,
+         * used to guard against a wrong delimiter or record_delimiter,
+         * default to 128000 characters.
+         */
+        max_record_size?: number;
+        /**
+         * Name of header-record title to name objects by.
+         */
+        objname?: string;
+        /**
+         * Alter and filter records by executing a user defined function.
+         */
+        on_record?: (record: any, context: CastingContext) => any;
+        /**
+         * Optional character surrounding a field, one character only, defaults to double quotes.
+         */
+        quote?: string | boolean | Buffer | null;
+        /**
+         * Generate two properties raw and row where raw is the original CSV row content and row is the parsed array or object.
+         */
+        raw?: boolean;
+        /**
+         * Preserve quotes inside unquoted field.
+         */
+        relax?: boolean;
+        /**
+         * Discard inconsistent columns count, default to false.
+         */
+        relax_column_count?: boolean;
+        /**
+         * Discard inconsistent columns count when the record contains less fields than expected, default to false.
+         */
+        relax_column_count_less?: boolean;
+        /**
+         * Discard inconsistent columns count when the record contains more fields than expected, default to false.
+         */
+        relax_column_count_more?: boolean;
+        /**
+         * One or multiple characters used to delimit record rows; defaults to auto discovery if not provided.
+         * Supported auto discovery method are Linux ("\n"), Apple ("\r") and Windows ("\r\n") row delimiters.
+         */
+        record_delimiter?: string | string[] | Buffer | Buffer[];
+        /**
+         * If true, ignore whitespace immediately preceding the delimiter (i.e. right-trim all fields), defaults to false.
+         * Does not remove whitespace in a quoted field.
+         */
+        rtrim?: boolean;
+        /**
+         * Dont generate empty values for empty lines.
+         * Defaults to false
+         */
+        skip_empty_lines?: boolean;
+        /**
+         * Skip a line with error found inside and directly go process the next line.
+         */
+        skip_lines_with_error?: boolean;
+        /**
+         * Don't generate records for lines containing empty column values (column matching /\s*\/), defaults to false.
+         */
+        skip_lines_with_empty_values?: boolean;
+        /**
+         * Stop handling records after the requested number of records.
+         */
+        to?: number;
+        /**
+         * Stop handling records after the requested line number.
+         */
+        to_line?: number;
+        /**
+         * If true, ignore whitespace immediately around the delimiter, defaults to false.
+         * Does not remove whitespace in a quoted field.
+         */
+        trim?: boolean;
+    }
+
+    interface Info {
+        /**
+         * Count the number of lines being fully commented.
+         */
+        readonly comment_lines: number;
+        /**
+         * Count the number of processed empty lines.
+         */
+        readonly empty_lines: number;
+        /**
+         * The number of lines encountered in the source dataset, start at 1 for the first line.
+         */
+        readonly lines: number;
+        /**
+         * Count the number of processed records.
+         */
+        readonly records: number;
+        /**
+         * Number of non uniform records when `relax_column_count` is true.
+         */
+        readonly invalid_field_length: number;
+    }
+}

--- a/node_modules/csv-parse/lib/index.js
+++ b/node_modules/csv-parse/lib/index.js
@@ -1,0 +1,1118 @@
+
+/*
+CSV Parse
+
+Please look at the [project documentation](https://csv.js.org/parse/) for
+additional information.
+*/
+
+const { Transform } = require('stream')
+const ResizeableBuffer = require('./ResizeableBuffer')
+
+const tab = 9
+const nl = 10
+const np = 12
+const cr = 13
+const space = 32
+const bom_utf8 = Buffer.from([239, 187, 191])
+
+class Parser extends Transform {
+  constructor(opts = {}){
+    super({...{readableObjectMode: true}, ...opts})
+    const options = {}
+    // Merge with user options
+    for(let opt in opts){
+      options[underscore(opt)] = opts[opt]
+    }
+    // Normalize option `bom`
+    if(options.bom === undefined || options.bom === null || options.bom === false){
+      options.bom = false
+    }else if(options.bom !== true){
+      throw new CsvError('CSV_INVALID_OPTION_BOM', [
+        'Invalid option bom:', 'bom must be true,',
+        `got ${JSON.stringify(options.bom)}`
+      ])
+    }
+    // Normalize option `cast`
+    let fnCastField = null
+    if(options.cast === undefined || options.cast === null || options.cast === false || options.cast === ''){
+      options.cast = undefined
+    }else if(typeof options.cast === 'function'){
+      fnCastField = options.cast
+      options.cast = true
+    }else if(options.cast !== true){
+      throw new CsvError('CSV_INVALID_OPTION_CAST', [
+        'Invalid option cast:', 'cast must be true or a function,',
+        `got ${JSON.stringify(options.cast)}`
+      ])
+    }
+    // Normalize option `cast_date`
+    if(options.cast_date === undefined || options.cast_date === null || options.cast_date === false || options.cast_date === ''){
+      options.cast_date = false
+    }else if(options.cast_date === true){
+      options.cast_date = function(value){
+        const date = Date.parse(value)
+        return !isNaN(date) ? new Date(date) : value
+      }
+    }else if(typeof options.cast_date !== 'function'){
+      throw new CsvError('CSV_INVALID_OPTION_CAST_DATE', [
+        'Invalid option cast_date:', 'cast_date must be true or a function,',
+        `got ${JSON.stringify(options.cast_date)}`
+      ])
+    }
+    // Normalize option `columns`
+    let fnFirstLineToHeaders = null
+    if(options.columns === true){
+      // Fields in the first line are converted as-is to columns
+      fnFirstLineToHeaders = undefined
+    }else if(typeof options.columns === 'function'){
+      fnFirstLineToHeaders = options.columns
+      options.columns = true
+    }else if(Array.isArray(options.columns)){
+      options.columns = normalizeColumnsArray(options.columns)
+    }else if(options.columns === undefined || options.columns === null || options.columns === false){
+      options.columns = false
+    }else{
+      throw new CsvError('CSV_INVALID_OPTION_COLUMNS', [
+        'Invalid option columns:',
+        'expect an object, a function or true,',
+        `got ${JSON.stringify(options.columns)}`
+      ])
+    }
+    // Normalize option `comment`
+    if(options.comment === undefined || options.comment === null || options.comment === false || options.comment === ''){
+      options.comment = null
+    }else{
+      if(typeof options.comment === 'string'){
+        options.comment = Buffer.from(options.comment)
+      }
+      if(!Buffer.isBuffer(options.comment)){
+        throw new CsvError('CSV_INVALID_OPTION_COMMENT', [
+          'Invalid option comment:',
+          'comment must be a buffer or a string,',
+          `got ${JSON.stringify(options.comment)}`
+        ])
+      }
+    }
+    // Normalize option `delimiter`
+    if(options.delimiter === undefined || options.delimiter === null || options.delimiter === false){
+      options.delimiter = Buffer.from(',')
+    }else if(typeof options.delimiter === 'string' && options.delimiter.length !== 0){
+      options.delimiter = Buffer.from(options.delimiter)
+    }else if(
+      (Buffer.isBuffer(options.delimiter) && options.delimiter.length === 0) ||
+      (typeof options.delimiter === 'string' && options.delimiter.length === 0) ||
+      (!Buffer.isBuffer(options.delimiter) && typeof options.delimiter !== 'string')
+    ){
+      throw new CsvError('CSV_INVALID_OPTION_DELIMITER', [
+        'Invalid option delimiter:',
+        'delimiter must be a non empty string or buffer,',
+        `got ${JSON.stringify(options.delimiter)}`
+      ])
+    }
+    // Normalize option `escape`
+    if(options.escape === undefined || options.escape === null){
+      options.escape = Buffer.from('"')
+    }else if(typeof options.escape === 'string'){
+      options.escape = Buffer.from(options.escape)
+    }
+    if(!Buffer.isBuffer(options.escape)){
+      throw new Error(`Invalid Option: escape must be a buffer or a string, got ${JSON.stringify(options.escape)}`)
+    }else if(options.escape.length !== 1){
+      throw new Error(`Invalid Option Length: escape must be one character, got ${options.escape.length}`)
+    }else{
+      options.escape = options.escape[0]
+    }
+    // Normalize option `from`
+    if(options.from === undefined || options.from === null){
+      options.from = 1
+    }else{
+      if(typeof options.from === 'string' && /\d+/.test(options.from)){
+        options.from = parseInt(options.from)
+      }
+      if(Number.isInteger(options.from)){
+        if(options.from < 0){
+          throw new Error(`Invalid Option: from must be a positive integer, got ${JSON.stringify(opts.from)}`)
+        }
+      }else{
+        throw new Error(`Invalid Option: from must be an integer, got ${JSON.stringify(options.from)}`)
+      }
+    }
+    // Normalize option `from_line`
+    if(options.from_line === undefined || options.from_line === null){
+      options.from_line = 1
+    }else{
+      if(typeof options.from_line === 'string' && /\d+/.test(options.from_line)){
+        options.from_line = parseInt(options.from_line)
+      }
+      if(Number.isInteger(options.from_line)){
+        if(options.from_line <= 0){
+          throw new Error(`Invalid Option: from_line must be a positive integer greater than 0, got ${JSON.stringify(opts.from_line)}`)
+        }
+      }else{
+        throw new Error(`Invalid Option: from_line must be an integer, got ${JSON.stringify(opts.from_line)}`)
+      }
+    }
+    // Normalize option `info`
+    if(options.info === undefined || options.info === null || options.info === false){
+      options.info = false
+    }else if(options.info !== true){
+      throw new Error(`Invalid Option: info must be true, got ${JSON.stringify(options.info)}`)
+    }
+    // Normalize option `max_record_size`
+    if(options.max_record_size === undefined || options.max_record_size === null || options.max_record_size === false){
+      options.max_record_size = 0
+    }else if(Number.isInteger(options.max_record_size) && options.max_record_size >= 0){
+      // Great, nothing to do
+    }else if(typeof options.max_record_size === 'string' && /\d+/.test(options.max_record_size)){
+      options.max_record_size = parseInt(options.max_record_size)
+    }else{
+      throw new Error(`Invalid Option: max_record_size must be a positive integer, got ${JSON.stringify(options.max_record_size)}`)
+    }
+    // Normalize option `objname`
+    if(options.objname === undefined || options.objname === null || options.objname === false){
+      options.objname = undefined
+    }else if(Buffer.isBuffer(options.objname)){
+      if(options.objname.length === 0){
+        throw new Error(`Invalid Option: objname must be a non empty buffer`)
+      }
+      options.objname = options.objname.toString()
+    }else if(typeof options.objname === 'string'){
+      if(options.objname.length === 0){
+        throw new Error(`Invalid Option: objname must be a non empty string`)
+      }
+      // Great, nothing to do
+    }else{
+      throw new Error(`Invalid Option: objname must be a string or a buffer, got ${options.objname}`)
+    }
+    // Normalize option `on_record`
+    if(options.on_record === undefined || options.on_record === null){
+      options.on_record = undefined
+    }else if(typeof options.on_record !== 'function'){
+      throw new CsvError('CSV_INVALID_OPTION_ON_RECORD', [
+        'Invalid option `on_record`:',
+        'expect a function,',
+        `got ${JSON.stringify(options.on_record)}`
+      ])
+    }
+    // Normalize option `quote`
+    if(options.quote === null || options.quote === false || options.quote === ''){
+      options.quote = null
+    }else{
+      if(options.quote === undefined || options.quote === true){
+        options.quote = Buffer.from('"')
+      }else if(typeof options.quote === 'string'){
+        options.quote = Buffer.from(options.quote)
+      }
+      if(!Buffer.isBuffer(options.quote)){
+        throw new Error(`Invalid Option: quote must be a buffer or a string, got ${JSON.stringify(options.quote)}`)
+      }else if(options.quote.length !== 1){
+        throw new Error(`Invalid Option Length: quote must be one character, got ${options.quote.length}`)
+      }else{
+        options.quote = options.quote[0]
+      }
+    }
+    // Normalize option `raw`
+    if(options.raw === undefined || options.raw === null || options.raw === false){
+      options.raw = false
+    }else if(options.raw !== true){
+      throw new Error(`Invalid Option: raw must be true, got ${JSON.stringify(options.raw)}`)
+    }
+    // Normalize option `record_delimiter`
+    if(!options.record_delimiter){
+      options.record_delimiter = []
+    }else if(!Array.isArray(options.record_delimiter)){
+      options.record_delimiter = [options.record_delimiter]
+    }
+    options.record_delimiter = options.record_delimiter.map( function(rd){
+      if(typeof rd === 'string'){
+        rd = Buffer.from(rd)
+      }
+      return rd
+    })
+    // Normalize option `relax`
+    if(typeof options.relax === 'boolean'){
+      // Great, nothing to do
+    }else if(options.relax === undefined || options.relax === null){
+      options.relax = false
+    }else{
+      throw new Error(`Invalid Option: relax must be a boolean, got ${JSON.stringify(options.relax)}`)
+    }
+    // Normalize option `relax_column_count`
+    if(typeof options.relax_column_count === 'boolean'){
+      // Great, nothing to do
+    }else if(options.relax_column_count === undefined || options.relax_column_count === null){
+      options.relax_column_count = false
+    }else{
+      throw new Error(`Invalid Option: relax_column_count must be a boolean, got ${JSON.stringify(options.relax_column_count)}`)
+    }
+    if(typeof options.relax_column_count_less === 'boolean'){
+      // Great, nothing to do
+    }else if(options.relax_column_count_less === undefined || options.relax_column_count_less === null){
+      options.relax_column_count_less = false
+    }else{
+      throw new Error(`Invalid Option: relax_column_count_less must be a boolean, got ${JSON.stringify(options.relax_column_count_less)}`)
+    }
+    if(typeof options.relax_column_count_more === 'boolean'){
+      // Great, nothing to do
+    }else if(options.relax_column_count_more === undefined || options.relax_column_count_more === null){
+      options.relax_column_count_more = false
+    }else{
+      throw new Error(`Invalid Option: relax_column_count_more must be a boolean, got ${JSON.stringify(options.relax_column_count_more)}`)
+    }
+    // Normalize option `skip_empty_lines`
+    if(typeof options.skip_empty_lines === 'boolean'){
+      // Great, nothing to do
+    }else if(options.skip_empty_lines === undefined || options.skip_empty_lines === null){
+      options.skip_empty_lines = false
+    }else{
+      throw new Error(`Invalid Option: skip_empty_lines must be a boolean, got ${JSON.stringify(options.skip_empty_lines)}`)
+    }
+    // Normalize option `skip_lines_with_empty_values`
+    if(typeof options.skip_lines_with_empty_values === 'boolean'){
+      // Great, nothing to do
+    }else if(options.skip_lines_with_empty_values === undefined || options.skip_lines_with_empty_values === null){
+      options.skip_lines_with_empty_values = false
+    }else{
+      throw new Error(`Invalid Option: skip_lines_with_empty_values must be a boolean, got ${JSON.stringify(options.skip_lines_with_empty_values)}`)
+    }
+    // Normalize option `skip_lines_with_error`
+    if(typeof options.skip_lines_with_error === 'boolean'){
+      // Great, nothing to do
+    }else if(options.skip_lines_with_error === undefined || options.skip_lines_with_error === null){
+      options.skip_lines_with_error = false
+    }else{
+      throw new Error(`Invalid Option: skip_lines_with_error must be a boolean, got ${JSON.stringify(options.skip_lines_with_error)}`)
+    }
+    // Normalize option `rtrim`
+    if(options.rtrim === undefined || options.rtrim === null || options.rtrim === false){
+      options.rtrim = false
+    }else if(options.rtrim !== true){
+      throw new Error(`Invalid Option: rtrim must be a boolean, got ${JSON.stringify(options.rtrim)}`)
+    }
+    // Normalize option `ltrim`
+    if(options.ltrim === undefined || options.ltrim === null || options.ltrim === false){
+      options.ltrim = false
+    }else if(options.ltrim !== true){
+      throw new Error(`Invalid Option: ltrim must be a boolean, got ${JSON.stringify(options.ltrim)}`)
+    }
+    // Normalize option `trim`
+    if(options.trim === undefined || options.trim === null || options.trim === false){
+      options.trim = false
+    }else if(options.trim !== true){
+      throw new Error(`Invalid Option: trim must be a boolean, got ${JSON.stringify(options.trim)}`)
+    }
+    // Normalize options `trim`, `ltrim` and `rtrim`
+    if(options.trim === true && opts.ltrim !== false){
+      options.ltrim = true
+    }else if(options.ltrim !== true){
+      options.ltrim = false
+    }
+    if(options.trim === true && opts.rtrim !== false){
+      options.rtrim = true
+    }else if(options.rtrim !== true){
+      options.rtrim = false
+    }
+    // Normalize option `to`
+    if(options.to === undefined || options.to === null){
+      options.to = -1
+    }else{
+      if(typeof options.to === 'string' && /\d+/.test(options.to)){
+        options.to = parseInt(options.to)
+      }
+      if(Number.isInteger(options.to)){
+        if(options.to <= 0){
+          throw new Error(`Invalid Option: to must be a positive integer greater than 0, got ${JSON.stringify(opts.to)}`)
+        }
+      }else{
+        throw new Error(`Invalid Option: to must be an integer, got ${JSON.stringify(opts.to)}`)
+      }
+    }
+    // Normalize option `to_line`
+    if(options.to_line === undefined || options.to_line === null){
+      options.to_line = -1
+    }else{
+      if(typeof options.to_line === 'string' && /\d+/.test(options.to_line)){
+        options.to_line = parseInt(options.to_line)
+      }
+      if(Number.isInteger(options.to_line)){
+        if(options.to_line <= 0){
+          throw new Error(`Invalid Option: to_line must be a positive integer greater than 0, got ${JSON.stringify(opts.to_line)}`)
+        }
+      }else{
+        throw new Error(`Invalid Option: to_line must be an integer, got ${JSON.stringify(opts.to_line)}`)
+      }
+    }
+    this.info = {
+      comment_lines: 0,
+      empty_lines: 0,
+      invalid_field_length: 0,
+      lines: 1,
+      records: 0
+    }
+    this.options = options
+    this.state = {
+      bomSkipped: false,
+      castField: fnCastField,
+      commenting: false,
+      enabled: options.from_line === 1,
+      escaping: false,
+      escapeIsQuote: options.escape === options.quote,
+      expectedRecordLength: options.columns === null ? 0 : options.columns.length,
+      field: new ResizeableBuffer(20),
+      firstLineToHeaders: fnFirstLineToHeaders,
+      info: Object.assign({}, this.info),
+      previousBuf: undefined,
+      quoting: false,
+      stop: false,
+      rawBuffer: new ResizeableBuffer(100),
+      record: [],
+      recordHasError: false,
+      record_length: 0,
+      recordDelimiterMaxLength: options.record_delimiter.length === 0 ? 2 : Math.max(...options.record_delimiter.map( (v) => v.length)),
+      trimChars: [Buffer.from(' ')[0], Buffer.from('\t')[0]],
+      wasQuoting: false,
+      wasRowDelimiter: false
+    }
+  }
+  // Implementation of `Transform._transform`
+  _transform(buf, encoding, callback){
+    if(this.state.stop === true){
+      return
+    }
+    const err = this.__parse(buf, false)
+    if(err !== undefined){
+      this.state.stop = true
+    }
+    callback(err)
+  }
+  // Implementation of `Transform._flush`
+  _flush(callback){
+    if(this.state.stop === true){
+      return
+    }
+    const err = this.__parse(undefined, true)
+    callback(err)
+  }
+  // Central parser implementation
+  __parse(nextBuf, end){
+    const {bom, comment, escape, from_line, info, ltrim, max_record_size, quote, raw, relax, rtrim, skip_empty_lines, to, to_line} = this.options
+    let {record_delimiter} = this.options
+    const {bomSkipped, previousBuf, rawBuffer, escapeIsQuote} = this.state
+    let buf
+    if(previousBuf === undefined){
+      if(nextBuf === undefined){
+        // Handle empty string
+        this.push(null)
+        return
+      }else{
+        buf = nextBuf
+      }
+    }else if(previousBuf !== undefined && nextBuf === undefined){
+      buf = previousBuf
+    }else{
+      buf = Buffer.concat([previousBuf, nextBuf])
+    }
+    // Handle UTF BOM
+    if(bomSkipped === false){
+      if(bom === false){
+        this.state.bomSkipped = true
+      }else if(buf.length < 3){
+        // No enough data
+        if(end === false){
+          // Wait for more data
+          this.state.previousBuf = buf
+          return
+        }
+        // skip BOM detect because data length < 3
+      }else{
+        if(bom_utf8.compare(buf, 0, 3) === 0){
+          // Skip BOM
+          buf = buf.slice(3)
+        }
+        this.state.bomSkipped = true
+      }
+    }
+    const bufLen = buf.length
+    let pos
+    for(pos = 0; pos < bufLen; pos++){
+      // Ensure we get enough space to look ahead
+      // There should be a way to move this out of the loop
+      if(this.__needMoreData(pos, bufLen, end)){
+        break
+      }
+      if(this.state.wasRowDelimiter === true){
+        this.info.lines++
+        if(info === true && this.state.record.length === 0 && this.state.field.length === 0 && this.state.wasQuoting === false){
+          this.state.info = Object.assign({}, this.info)
+        }
+        this.state.wasRowDelimiter = false
+      }
+      if(to_line !== -1 && this.info.lines > to_line){
+        this.state.stop = true
+        this.push(null)
+        return
+      }
+      // Auto discovery of record_delimiter, unix, mac and windows supported
+      if(this.state.quoting === false && record_delimiter.length === 0){
+        const record_delimiterCount = this.__autoDiscoverRowDelimiter(buf, pos)
+        if(record_delimiterCount){
+          record_delimiter = this.options.record_delimiter
+        }
+      }
+      const chr = buf[pos]
+      if(raw === true){
+        rawBuffer.append(chr)
+      }
+      if((chr === cr || chr === nl) && this.state.wasRowDelimiter === false ){
+        this.state.wasRowDelimiter = true
+      }
+      // Previous char was a valid escape char
+      // treat the current char as a regular char
+      if(this.state.escaping === true){
+        this.state.escaping = false
+      }else{
+        // Escape is only active inside quoted fields
+        // We are quoting, the char is an escape chr and there is a chr to escape
+        if(this.state.quoting === true && chr === escape && pos + 1 < bufLen){
+          if(escapeIsQuote){
+            if(buf[pos+1] === quote){
+              this.state.escaping = true
+              continue
+            }
+          }else{
+            this.state.escaping = true
+            continue
+          }
+        }
+        // Not currently escaping and chr is a quote
+        // TODO: need to compare bytes instead of single char
+        if(this.state.commenting === false && chr === quote){
+          if(this.state.quoting === true){
+            const nextChr = buf[pos+1]
+            const isNextChrTrimable = rtrim && this.__isCharTrimable(nextChr)
+            // const isNextChrComment = nextChr === comment
+            const isNextChrComment = comment !== null && this.__compareBytes(comment, buf, pos+1, nextChr)
+            const isNextChrDelimiter = this.__isDelimiter(nextChr, buf, pos+1)
+            const isNextChrRowDelimiter = record_delimiter.length === 0 ? this.__autoDiscoverRowDelimiter(buf, pos+1) : this.__isRecordDelimiter(nextChr, buf, pos+1)
+            // Escape a quote
+            // Treat next char as a regular character
+            // TODO: need to compare bytes instead of single char
+            if(chr === escape && nextChr === quote){
+              pos++
+            }else if(!nextChr || isNextChrDelimiter || isNextChrRowDelimiter || isNextChrComment || isNextChrTrimable){
+              this.state.quoting = false
+              this.state.wasQuoting = true
+              continue
+            }else if(relax === false){
+              const err = this.__error(
+                new CsvError('CSV_INVALID_CLOSING_QUOTE', [
+                  'Invalid Closing Quote:',
+                  `got "${String.fromCharCode(nextChr)}"`,
+                  `at line ${this.info.lines}`,
+                  'instead of delimiter, row delimiter, trimable character',
+                  '(if activated) or comment',
+                ], this.__context())
+              )
+              if(err !== undefined) return err
+            }else{
+              this.state.quoting = false
+              this.state.wasQuoting = true
+              // continue
+              this.state.field.prepend(quote)
+            }
+          }else{
+            if(this.state.field.length !== 0){
+              // In relax mode, treat opening quote preceded by chrs as regular
+              if( relax === false ){
+                const err = this.__error(
+                  new CsvError('INVALID_OPENING_QUOTE', [
+                    'Invalid Opening Quote:',
+                    `a quote is found inside a field at line ${this.info.lines}`,
+                  ], this.__context(), {
+                    field: this.state.field,
+                  })
+                )
+                if(err !== undefined) return err
+              }
+            }else{
+              this.state.quoting = true
+              continue
+            }
+          }
+        }
+        if(this.state.quoting === false){
+          let recordDelimiterLength = this.__isRecordDelimiter(chr, buf, pos)
+          if(recordDelimiterLength !== 0){
+            // Do not emit comments which take a full line
+            const skipCommentLine = this.state.commenting && (this.state.wasQuoting === false && this.state.record.length === 0 && this.state.field.length === 0)
+            if(skipCommentLine){
+              this.info.comment_lines++
+              // Skip full comment line
+            }else{
+              // Skip if line is empty and skip_empty_lines activated
+              if(skip_empty_lines === true && this.state.wasQuoting === false && this.state.record.length === 0 && this.state.field.length === 0){
+                this.info.empty_lines++
+                pos += recordDelimiterLength - 1
+                continue
+              }
+              // Activate records emition if above from_line
+              if(this.state.enabled === false && this.info.lines + (this.state.wasRowDelimiter === true ? 1: 0 ) >= from_line){
+                this.state.enabled = true
+                this.__resetField()
+                this.__resetRow()
+                pos += recordDelimiterLength - 1
+                continue
+              }else{
+                const errField = this.__onField()
+                if(errField !== undefined) return errField
+                const errRecord = this.__onRow()
+                if(errRecord !== undefined) return errRecord
+              }
+              if(to !== -1 && this.info.records >= to){
+                this.state.stop = true
+                this.push(null)
+                return
+              }
+            }
+            this.state.commenting = false
+            pos += recordDelimiterLength - 1
+            continue
+          }
+          if(this.state.commenting){
+            continue
+          }
+          const commentCount = comment === null ? 0 : this.__compareBytes(comment, buf, pos, chr)
+          if(commentCount !== 0){
+            this.state.commenting = true
+            continue
+          }
+          let delimiterLength = this.__isDelimiter(chr, buf, pos)
+          if(delimiterLength !== 0){
+            const errField = this.__onField()
+            if(errField !== undefined) return errField
+            pos += delimiterLength - 1
+            continue
+          }
+        }
+      }
+      if(this.state.commenting === false){
+        if(max_record_size !== 0 && this.state.record_length + this.state.field.length > max_record_size){
+          const err = this.__error(
+            new CsvError('CSV_MAX_RECORD_SIZE', [
+              'Max Record Size:',
+              'record exceed the maximum number of tolerated bytes',
+              `of ${max_record_size}`,
+              `at line ${this.info.lines}`,
+            ], this.__context())
+          )
+          if(err !== undefined) return err
+        }
+      }
+
+      const lappend = ltrim === false || this.state.quoting === true || this.state.field.length !== 0 || !this.__isCharTrimable(chr)
+      // rtrim in non quoting is handle in __onField
+      const rappend = rtrim === false || this.state.wasQuoting === false
+      if( lappend === true && rappend === true ){
+        this.state.field.append(chr)
+      }else if(rtrim === true && !this.__isCharTrimable(chr)){
+        const err = this.__error(
+          new CsvError('CSV_NON_TRIMABLE_CHAR_AFTER_CLOSING_QUOTE', [
+            'Invalid Closing Quote:',
+            'found non trimable byte after quote',
+            `at line ${this.info.lines}`,
+          ], this.__context())
+        )
+        if(err !== undefined) return err
+      }
+    }
+    if(end === true){
+      // Ensure we are not ending in a quoting state
+      if(this.state.quoting === true){
+        const err = this.__error(
+          new CsvError('CSV_QUOTE_NOT_CLOSED', [
+            'Quote Not Closed:',
+            `the parsing is finished with an opening quote at line ${this.info.lines}`,
+          ], this.__context())
+        )
+        if(err !== undefined) return err
+      }else{
+        // Skip last line if it has no characters
+        if(this.state.wasQuoting === true || this.state.record.length !== 0 || this.state.field.length !== 0){
+          const errField = this.__onField()
+          if(errField !== undefined) return errField
+          const errRecord = this.__onRow()
+          if(errRecord !== undefined) return errRecord
+        }else if(this.state.wasRowDelimiter === true){
+          this.info.empty_lines++
+        }else if(this.state.commenting === true){
+          this.info.comment_lines++
+        }
+      }
+    }else{
+      this.state.previousBuf = buf.slice(pos)
+    }
+    if(this.state.wasRowDelimiter === true){
+      this.info.lines++
+      this.state.wasRowDelimiter = false
+    }
+  }
+  // Helper to test if a character is a space or a line delimiter
+  __isCharTrimable(chr){
+    return chr === space || chr === tab || chr === cr || chr === nl || chr === np
+  }
+  __onRow(){
+    const {columns, info, from, relax_column_count, relax_column_count_less, relax_column_count_more, raw, skip_lines_with_empty_values} = this.options
+    const {enabled, record} = this.state
+    if(enabled === false){
+      return this.__resetRow()
+    }
+    // Convert the first line into column names
+    const recordLength = record.length
+    if(columns === true){
+      if(isRecordEmpty(record)){
+        this.__resetRow()
+        return
+      }
+      return this.__firstLineToColumns(record)
+    }
+    if(columns === false && this.info.records === 0){
+      this.state.expectedRecordLength = recordLength
+    }
+    if(recordLength !== this.state.expectedRecordLength){
+      if(relax_column_count === true || 
+        (relax_column_count_less === true && recordLength < this.state.expectedRecordLength) ||
+        (relax_column_count_more === true && recordLength > this.state.expectedRecordLength) ){
+        this.info.invalid_field_length++
+      }else{
+        if(columns === false){
+          const err = this.__error(
+            new CsvError('CSV_INCONSISTENT_RECORD_LENGTH', [
+              'Invalid Record Length:',
+              `expect ${this.state.expectedRecordLength},`,
+              `got ${recordLength} on line ${this.info.lines}`,
+            ], this.__context(), {
+              record: record,
+            })
+          )
+          if(err !== undefined) return err
+        }else{
+          const err = this.__error(
+            // CSV_INVALID_RECORD_LENGTH_DONT_MATCH_COLUMNS
+            new CsvError('CSV_RECORD_DONT_MATCH_COLUMNS_LENGTH', [
+              'Invalid Record Length:',
+              `columns length is ${columns.length},`, // rename columns
+              `got ${recordLength} on line ${this.info.lines}`,
+            ], this.__context(), {
+              record: record,
+            })
+          )
+          if(err !== undefined) return err
+        }
+      }
+    }
+    if(skip_lines_with_empty_values === true){
+      if(isRecordEmpty(record)){
+        this.__resetRow()
+        return
+      }
+    }
+    if(this.state.recordHasError === true){
+      this.__resetRow()
+      this.state.recordHasError = false
+      return
+    }
+    this.info.records++
+    if(from === 1 || this.info.records >= from){
+      if(columns !== false){
+        const obj = {}
+        // Transform record array to an object
+        for(let i = 0, l = record.length; i < l; i++){
+          if(columns[i] === undefined || columns[i].disabled) continue
+          obj[columns[i].name] = record[i]
+        }
+        const {objname} = this.options
+        if(objname === undefined){
+          if(raw === true || info === true){
+            const err = this.__push(Object.assign(
+              {record: obj},
+              (raw === true ? {raw: this.state.rawBuffer.toString()}: {}),
+              (info === true ? {info: this.state.info}: {})
+            ))
+            if(err){
+              return err
+            }
+          }else{
+            const err = this.__push(obj)
+            if(err){
+              return err
+            }
+          }
+        }else{
+          if(raw === true || info === true){
+            const err = this.__push(Object.assign(
+              {record: [obj[objname], obj]},
+              raw === true ? {raw: this.state.rawBuffer.toString()}: {},
+              info === true ? {info: this.state.info}: {}
+            ))
+            if(err){
+              return err
+            }
+          }else{
+            const err = this.__push([obj[objname], obj])
+            if(err){
+              return err
+            }
+          }
+        }
+      }else{
+        if(raw === true || info === true){
+          const err = this.__push(Object.assign(
+            {record: record},
+            raw === true ? {raw: this.state.rawBuffer.toString()}: {},
+            info === true ? {info: this.state.info}: {}
+          ))
+          if(err){
+            return err
+          }
+        }else{
+          const err = this.__push(record)
+          if(err){
+            return err
+          }
+        }
+      }
+    }
+    this.__resetRow()
+  }
+  __firstLineToColumns(record){
+    const {firstLineToHeaders} = this.state
+    try{
+      const headers = firstLineToHeaders === undefined ? record : firstLineToHeaders.call(null, record)
+      if(!Array.isArray(headers)){
+        return this.__error(
+          new CsvError('CSV_INVALID_COLUMN_MAPPING', [
+            'Invalid Column Mapping:',
+            'expect an array from column function,',
+            `got ${JSON.stringify(headers)}`
+          ], this.__context(), {
+            headers: headers,
+          })
+        )
+      }
+      const normalizedHeaders = normalizeColumnsArray(headers)
+      this.state.expectedRecordLength = normalizedHeaders.length
+      this.options.columns = normalizedHeaders
+      this.__resetRow()
+      return
+    }catch(err){
+      return err
+    }
+  }
+  __resetRow(){
+    if(this.options.raw === true){
+      this.state.rawBuffer.reset()
+    }
+    this.state.record = []
+    this.state.record_length = 0
+  }
+  __onField(){
+    const {cast, rtrim, max_record_size} = this.options
+    const {enabled, wasQuoting} = this.state
+    // Short circuit for the from_line options
+    if(enabled === false){ /* this.options.columns !== true && */
+      return this.__resetField()
+    }
+    let field = this.state.field.toString()
+    if(rtrim === true && wasQuoting === false){
+      field = field.trimRight()
+    }
+    if(cast === true){
+      const [err, f] = this.__cast(field)
+      if(err !== undefined) return err
+      field = f
+    }
+    this.state.record.push(field)
+    // Increment record length if record size must not exceed a limit
+    if(max_record_size !== 0 && typeof field === 'string'){
+      this.state.record_length += field.length
+    }
+    this.__resetField()
+  }
+  __resetField(){
+    this.state.field.reset()
+    this.state.wasQuoting = false
+  }
+  __push(record){
+    const {on_record} = this.options
+    if(on_record !== undefined){
+      const context = this.__context()
+      try{
+        record = on_record.call(null, record, context)
+      }catch(err){
+        return err
+      }
+      if(record === undefined || record === null){ return }
+    }
+    this.push(record)
+  }
+  // Return a tuple with the error and the casted value
+  __cast(field){
+    const {columns, relax_column_count} = this.options
+    const isColumns = Array.isArray(columns)
+    // Dont loose time calling cast
+    // because the final record is an object
+    // and this field can't be associated to a key present in columns
+    if( isColumns === true && relax_column_count && this.options.columns.length <= this.state.record.length ){
+      return [undefined, undefined]
+    }
+    const context = this.__context()
+    if(this.state.castField !== null){
+      try{
+        return [undefined, this.state.castField.call(null, field, context)]
+      }catch(err){
+        return [err]
+      }
+    }
+    if(this.__isFloat(field)){
+      return [undefined, parseFloat(field)]
+    }else if(this.options.cast_date !== false){
+      return [undefined, this.options.cast_date.call(null, field, context)]
+    }
+    return [undefined, field]
+  }
+  // Keep it in case we implement the `cast_int` option
+  // __isInt(value){
+  //   // return Number.isInteger(parseInt(value))
+  //   // return !isNaN( parseInt( obj ) );
+  //   return /^(\-|\+)?[1-9][0-9]*$/.test(value)
+  // }
+  __isFloat(value){
+    return (value - parseFloat( value ) + 1) >= 0 // Borrowed from jquery
+  }
+  __compareBytes(sourceBuf, targetBuf, pos, firtByte){
+    if(sourceBuf[0] !== firtByte) return 0
+    const sourceLength = sourceBuf.length
+    for(let i = 1; i < sourceLength; i++){
+      if(sourceBuf[i] !== targetBuf[pos+i]) return 0
+    }
+    return sourceLength
+  }
+  __needMoreData(i, bufLen, end){
+    if(end){
+      return false
+    }
+    const {comment, delimiter} = this.options
+    const {quoting, recordDelimiterMaxLength} = this.state
+    const numOfCharLeft = bufLen - i - 1
+    const requiredLength = Math.max(
+      // Skip if the remaining buffer smaller than comment
+      comment ? comment.length : 0,
+      // Skip if the remaining buffer smaller than row delimiter
+      recordDelimiterMaxLength,
+      // Skip if the remaining buffer can be row delimiter following the closing quote
+      // 1 is for quote.length
+      quoting ? (1 + recordDelimiterMaxLength) : 0,
+      // Skip if the remaining buffer can be delimiter
+      delimiter.length,
+      // Skip if the remaining buffer can be escape sequence
+      // 1 is for escape.length
+      1
+    )
+    return numOfCharLeft < requiredLength
+  }
+  __isDelimiter(chr, buf, pos){
+    const {delimiter} = this.options
+    const delLength = delimiter.length
+    if(delimiter[0] !== chr) return 0
+    for(let i = 1; i < delLength; i++){
+      if(delimiter[i] !== buf[pos+i]) return 0
+    }
+    return delimiter.length
+  }
+  __isRecordDelimiter(chr, buf, pos){
+    const {record_delimiter} = this.options
+    const recordDelimiterLength = record_delimiter.length
+    loop1: for(let i = 0; i < recordDelimiterLength; i++){
+      const rd = record_delimiter[i]
+      const rdLength = rd.length
+      if(rd[0] !== chr){
+        continue
+      }
+      for(let j = 1; j < rdLength; j++){
+        if(rd[j] !== buf[pos+j]){
+          continue loop1
+        }
+      }
+      return rd.length
+    }
+    return 0
+  }
+  __autoDiscoverRowDelimiter(buf, pos){
+    const chr = buf[pos]
+    if(chr === cr){
+      if(buf[pos+1] === nl){
+        this.options.record_delimiter.push(Buffer.from('\r\n'))
+        this.state.recordDelimiterMaxLength = 2
+        return 2
+      }else{
+        this.options.record_delimiter.push(Buffer.from('\r'))
+        this.state.recordDelimiterMaxLength = 1
+        return 1
+      }
+    }else if(chr === nl){
+      this.options.record_delimiter.push(Buffer.from('\n'))
+      this.state.recordDelimiterMaxLength = 1
+      return 1
+    }
+    return 0
+  }
+  __error(msg){
+    const {skip_lines_with_error} = this.options
+    const err = typeof msg === 'string' ? new Error(msg) : msg
+    if(skip_lines_with_error){
+      this.state.recordHasError = true
+      this.emit('skip', err)
+      return undefined
+    }else{
+      return err
+    }
+  }
+  __context(){
+    const {columns} = this.options
+    const isColumns = Array.isArray(columns)
+    return {
+      column: isColumns === true ?
+        ( columns.length > this.state.record.length ?
+          columns[this.state.record.length].name :
+          null
+        ) :
+        this.state.record.length,
+      empty_lines: this.info.empty_lines,
+      header: columns === true,
+      index: this.state.record.length,
+      invalid_field_length: this.info.invalid_field_length,
+      quoting: this.state.wasQuoting,
+      lines: this.info.lines,
+      records: this.info.records
+    }
+  }
+}
+
+const parse = function(){
+  let data, options, callback
+  for(let i in arguments){
+    const argument = arguments[i]
+    const type = typeof argument
+    if(data === undefined && (typeof argument === 'string' || Buffer.isBuffer(argument))){
+      data = argument
+    }else if(options === undefined && isObject(argument)){
+      options = argument
+    }else if(callback === undefined && type === 'function'){
+      callback = argument
+    }else{
+      throw new CsvError('CSV_INVALID_ARGUMENT', [
+        'Invalid argument:',
+        `got ${JSON.stringify(argument)} at index ${i}`
+      ])
+    }
+  }
+  const parser = new Parser(options)
+  if(callback){
+    const records = options === undefined || options.objname === undefined ? [] : {}
+    parser.on('readable', function(){
+      let record
+      while((record = this.read()) !== null){
+        if(options === undefined || options.objname === undefined){
+          records.push(record)
+        }else{
+          records[record[0]] = record[1]
+        }
+      }
+    })
+    parser.on('error', function(err){
+      callback(err, undefined, parser.info)
+    })
+    parser.on('end', function(){
+      callback(undefined, records, parser.info)
+    })
+  }
+  if(data !== undefined){
+    // Give a chance for events to be registered later
+    if(typeof setImmediate === 'function'){
+      setImmediate(function(){
+        parser.write(data)
+        parser.end()
+      })
+    }else{
+      parser.write(data)
+      parser.end()
+    }
+  }
+  return parser
+}
+
+class CsvError extends Error {
+  constructor(code, message, ...contexts) {
+    if(Array.isArray(message)) message = message.join(' ')
+    super(message)
+    if(Error.captureStackTrace !== undefined){
+      Error.captureStackTrace(this, CsvError)
+    }
+    this.code = code
+    for(const context of contexts){
+      for(const key in context){
+        const value = context[key]
+        this[key] = Buffer.isBuffer(value) ? value.toString() : value == null ? value : JSON.parse(JSON.stringify(value))
+      }
+    }
+  }
+}
+
+parse.Parser = Parser
+
+parse.CsvError = CsvError
+
+module.exports = parse
+
+const underscore = function(str){
+  return str.replace(/([A-Z])/g, function(_, match){
+    return '_' + match.toLowerCase()
+  })
+}
+
+const isObject = function(obj){
+  return (typeof obj === 'object' && obj !== null && !Array.isArray(obj))
+}
+
+const isRecordEmpty = function(record){
+  return record.every( (field) => field == null || field.toString && field.toString().trim() === '' )
+}
+
+const normalizeColumnsArray = function(columns){
+  const normalizedColumns = [];
+  for(let i = 0, l = columns.length; i < l; i++){
+    const column = columns[i]
+    if(column === undefined || column === null || column === false){
+      normalizedColumns[i] = { disabled: true }
+    }else if(typeof column === 'string'){
+      normalizedColumns[i] = { name: column }
+    }else if(isObject(column)){
+      if(typeof column.name !== 'string'){
+        throw new CsvError('CSV_OPTION_COLUMNS_MISSING_NAME', [
+          'Option columns missing name:',
+          `property "name" is required at position ${i}`,
+          'when column is an object literal'
+        ])
+      }
+      normalizedColumns[i] = column
+    }else{
+      throw new CsvError('CSV_INVALID_COLUMN_DEFINITION', [
+        'Invalid column definition:',
+        'expect a string or a literal object,',
+        `got ${JSON.stringify(column)} at position ${i}`
+      ])
+    }
+  }
+  return normalizedColumns;
+}

--- a/node_modules/csv-parse/lib/sync.d.ts
+++ b/node_modules/csv-parse/lib/sync.d.ts
@@ -1,0 +1,6 @@
+import * as csvParse from './index';
+
+export = parse;
+
+declare function parse(input: Buffer | string, options?: csvParse.Options): any;
+declare namespace parse {}

--- a/node_modules/csv-parse/lib/sync.js
+++ b/node_modules/csv-parse/lib/sync.js
@@ -1,0 +1,25 @@
+
+const parse = require('.')
+
+module.exports = function(data, options={}){
+  if(typeof data === 'string'){
+    data = Buffer.from(data)
+  }
+  const records = options && options.objname ? {} : []
+  const parser = new parse.Parser(options)
+  parser.push = function(record){
+    if(record === null){
+      return
+    }
+    if(options.objname === undefined)
+      records.push(record)
+    else{
+      records[record[0]] = record[1]
+    }
+  }
+  const err1 = parser.__parse(data, false)
+  if(err1 !== undefined) throw err1
+  const err2 = parser.__parse(undefined, true)
+  if(err2 !== undefined) throw err2
+  return records
+}

--- a/node_modules/csv-parse/package.json
+++ b/node_modules/csv-parse/package.json
@@ -1,0 +1,168 @@
+{
+  "_from": "csv-parse@^4.8.9",
+  "_id": "csv-parse@4.8.9",
+  "_inBundle": false,
+  "_integrity": "sha512-uDxIDIDLb89gxqixSgGqDj3EA5A8D0pgUeyp9Qut8u+eCIC8IXkTtaxJEnnWDb6N2HqBY64suSlcOGg5ZBtsAQ==",
+  "_location": "/csv-parse",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "range",
+    "registry": true,
+    "raw": "csv-parse@^4.8.9",
+    "name": "csv-parse",
+    "escapedName": "csv-parse",
+    "rawSpec": "^4.8.9",
+    "saveSpec": null,
+    "fetchSpec": "^4.8.9"
+  },
+  "_requiredBy": [
+    "/"
+  ],
+  "_resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.8.9.tgz",
+  "_shasum": "0d3f0973f415677b01d17abaa221fbffc6125760",
+  "_spec": "csv-parse@^4.8.9",
+  "_where": "/Users/eric/Develop/projects/mjd-oss/super-transformer",
+  "author": {
+    "name": "David Worms",
+    "email": "david@adaltas.com",
+    "url": "https://www.adaltas.com"
+  },
+  "bugs": {
+    "url": "https://github.com/wdavidw/node-csv-parse/issues"
+  },
+  "bundleDependencies": false,
+  "coffeelintConfig": {
+    "indentation": {
+      "level": "error",
+      "value": 2
+    },
+    "line_endings": {
+      "level": "error",
+      "value": "unix"
+    },
+    "max_line_length": {
+      "level": "ignore"
+    }
+  },
+  "contributors": [
+    {
+      "name": "David Worms",
+      "email": "david@adaltas.com",
+      "url": "https://www.adaltas.com"
+    },
+    {
+      "name": "Will White",
+      "url": "https://github.com/willwhite"
+    },
+    {
+      "name": "Justin Latimer",
+      "url": "https://github.com/justinlatimer"
+    },
+    {
+      "name": "jonseymour",
+      "url": "https://github.com/jonseymour"
+    },
+    {
+      "name": "pascalopitz",
+      "url": "https://github.com/pascalopitz"
+    },
+    {
+      "name": "Josh Pschorr",
+      "url": "https://github.com/jpschorr"
+    },
+    {
+      "name": "Elad Ben-Israel",
+      "url": "https://github.com/eladb"
+    },
+    {
+      "name": "Philippe Plantier",
+      "url": "https://github.com/phipla"
+    },
+    {
+      "name": "Tim Oxley",
+      "url": "https://github.com/timoxley"
+    },
+    {
+      "name": "Damon Oehlman",
+      "url": "https://github.com/DamonOehlman"
+    },
+    {
+      "name": "Alexandru Topliceanu",
+      "url": "https://github.com/topliceanu"
+    },
+    {
+      "name": "Visup",
+      "url": "https://github.com/visup"
+    },
+    {
+      "name": "Edmund von der Burg",
+      "url": "https://github.com/evdb"
+    },
+    {
+      "name": "Douglas Christopher Wilson",
+      "url": "https://github.com/dougwilson"
+    },
+    {
+      "name": "Joe Eaves",
+      "url": "https://github.com/Joeasaurus"
+    },
+    {
+      "name": "Mark Stosberg",
+      "url": "https://github.com/markstos"
+    }
+  ],
+  "dependencies": {},
+  "deprecated": false,
+  "description": "CSV parsing implementing the Node.js `stream.Transform` API",
+  "devDependencies": {
+    "@babel/cli": "^7.5.5",
+    "@babel/core": "^7.5.5",
+    "@babel/preset-env": "^7.5.5",
+    "@types/mocha": "^5.2.7",
+    "@types/node": "^12.6.9",
+    "coffeescript": "^2.4.1",
+    "csv-generate": "^3.2.3",
+    "csv-spectrum": "^1.0.0",
+    "each": "^1.2.1",
+    "eslint": "^6.5.1",
+    "mocha": "^6.2.0",
+    "pad": "^3.2.0",
+    "should": "^13.2.3",
+    "stream-transform": "^2.0.1",
+    "ts-node": "^8.3.0",
+    "typescript": "^3.5.3"
+  },
+  "files": [
+    "/lib"
+  ],
+  "homepage": "https://csv.js.org/parse/",
+  "keywords": [
+    "csv",
+    "parse",
+    "parser",
+    "convert",
+    "tsv",
+    "stream"
+  ],
+  "license": "MIT",
+  "main": "./lib",
+  "name": "csv-parse",
+  "optionalDependencies": {},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wdavidw/node-csv-parse.git"
+  },
+  "scripts": {
+    "lint": "eslint lib/*.js",
+    "major": "npm version major -m 'Bump to version %s'",
+    "minor": "npm version minor -m 'Bump to version %s'",
+    "patch": "npm version patch -m 'Bump to version %s'",
+    "postversion": "git push && git push --tags && npm publish",
+    "pretest": "cd lib && babel *.js  -d es5 && cd ..",
+    "preversion": "grep '## Trunk' CHANGELOG.md && npm test && cp lib/*.ts lib/es5 && git add lib/es5/*.ts",
+    "test": "npm run lint && TS_NODE_COMPILER_OPTIONS='{\"strictNullChecks\":true}' mocha test/**/*.{coffee,ts}",
+    "version": "version=`grep '^  \"version\": ' package.json | sed 's/.*\"\\([0-9\\.]*\\)\".*/\\1/'` && sed -i \"s/## Trunk/## Version $version/\" CHANGELOG.md && git add CHANGELOG.md"
+  },
+  "types": "./lib/index.d.ts",
+  "version": "4.8.9"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "universal-p658-log-transformation-library",
-  "version": "1.0.4",
+  "name": "super-transformer",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -215,6 +215,11 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "csv-parse": {
+      "version": "4.8.9",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.8.9.tgz",
+      "integrity": "sha512-uDxIDIDLb89gxqixSgGqDj3EA5A8D0pgUeyp9Qut8u+eCIC8IXkTtaxJEnnWDb6N2HqBY64suSlcOGg5ZBtsAQ=="
     },
     "debug": {
       "version": "3.2.6",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "handlebars": "^4.7.6",
-    "commander": "^5.0.0"
+    "commander": "^5.0.0",
+    "csv-parse": "^4.8.9"
   },
   "devDependencies": {
     "prettier": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "super-transformer",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "This package provides scripts to transform incoming strings using templates. It receives string representations of various formats (JSON, CSV) and returns a string after transforming the incoming data.",
   "author": "Eric Soto <eric.soto@valtech.com>",
   "main": "index.js",

--- a/template-examples/demo-simple-flat.json
+++ b/template-examples/demo-simple-flat.json
@@ -1,0 +1,5 @@
+{
+  "customerName": "{{first_name}}{{#if last_name}} {{last_name}}{{/if}}",
+  "customerCity": "{{customer_city}}",
+  "fteSince": {{hire_year}}
+}

--- a/template-examples/demo-simple.json
+++ b/template-examples/demo-simple.json
@@ -1,3 +1,1 @@
-{
-  "customerName": "{{customer.name}}"
-}
+{ "customerName": "{{customer.name}}" }

--- a/tests/JSONHelperTests.js
+++ b/tests/JSONHelperTests.js
@@ -1,0 +1,25 @@
+const JSONHelper = require('./../lib/JSONHelper.js');
+const mocha = require('mocha');
+const describe = mocha.describe;
+const it = mocha.it;
+const chai = require('chai');
+const expect = chai.expect;
+chai.should();
+
+describe('JSONHelper Tests', function () {
+  describe('parseJson', function () {
+    it('returns an object when passed a good JSON string', function () {
+      const output = JSONHelper.parseJson('{"customer": {"name": "John"}}');
+      output.should.exist;
+      expect(output).to.deep.equal({
+        customer: {
+          name: 'John',
+        },
+      });
+    });
+    it('returns null when passed a bad JSON string', function () {
+      const output = JSONHelper.parseJson('{customer": {"name: "John"}}');
+      expect(output).to.be.null;
+    });
+  });
+});

--- a/tests/TemplateHelperTests.js
+++ b/tests/TemplateHelperTests.js
@@ -30,7 +30,7 @@ describe('TemplateHelper Tests', function () {
         },
       };
       const templateOutput = TemplateHelper.applyTemplate(
-        './template-examples/demo-simple.json',
+        '{ "customerName": "{{customer.name}}" }',
         contextData
       );
       // console.log(`templateOutput:\n${templateOutput}`);
@@ -39,6 +39,7 @@ describe('TemplateHelper Tests', function () {
         /{{/,
         'Applied template should not have any mustaches {{}} left over!'
       );
+      expect(templateOutput).to.equal('{ "customerName": "John" }');
     });
   });
 });

--- a/tests/XSVHelperTests.js
+++ b/tests/XSVHelperTests.js
@@ -1,0 +1,30 @@
+const XSVHelper = require('./../lib/XSVHelper.js');
+const mocha = require('mocha');
+const describe = mocha.describe;
+const it = mocha.it;
+const chai = require('chai');
+const expect = chai.expect;
+chai.should();
+
+describe('XSVHelper Tests', function () {
+  describe('parseXsv', function () {
+    it('returns an object when passed a good delimited string with matching columns', function () {
+      const input = '"john", "smith", "Davenport, FL", 2017';
+      const delimiter = ',';
+      const columnLayout = 'first_name, last_name, customer_city, hire_year';
+      const output = XSVHelper.parseXsv(input, delimiter, columnLayout);
+      output.should.exist;
+      expect(output).to.deep.equal(
+        [
+          {
+            first_name: 'john',
+            last_name: 'smith',
+            customer_city: 'Davenport, FL',
+            hire_year: '2017',
+          },
+        ],
+        'output object was not as expected!'
+      );
+    });
+  });
+});

--- a/transformDelimited.js
+++ b/transformDelimited.js
@@ -2,11 +2,12 @@
 
 // Include our needed dependencies
 const TemplateHelper = require('./lib/TemplateHelper.js');
-const JSONHelper = require('./lib/JSONHelper.js');
+const XSVHelper = require('./lib/XSVHelper.js');
 const program = require('commander');
 const pkg = require('./package.json');
 const fs = require('fs');
 const path = require('path');
+const assert = require('assert');
 
 // Set aside a variable to hold our inputObject once we parse it from JSON
 // These will be set by our programSetup
@@ -16,13 +17,33 @@ let inputObject, absoluteTemplatePath;
 programSetup(program);
 
 // ASSERT: programSetup would exit if the CL arguments were bad. So, we have good arguments if we're here!
-// ASSERT: inputObject has a valid object (derived from the input JSON string.)
 // ASSERT: absoluteTemplatePath has a valid path and the template file exists.
 
-// Transform
-console.log(
-  TemplateHelper.applyTemplateWithFilePath(absoluteTemplatePath, inputObject)
-);
+try {
+  // Parse our input data into an inputObject
+  inputObject = XSVHelper.parseXsv(
+    program.inputdata,
+    program.delimiter,
+    program.columnLayout
+  );
+
+  // ASSERT: our parseXsv returns an array, but we expect a single item!
+  assert(
+    inputObject.length === 1,
+    `ERROR: transformDelimited parsed more than one row! Expected a single row.`
+  );
+
+  // Transform, notice we pass in the single row we expect!
+  console.log(
+    TemplateHelper.applyTemplateWithFilePath(
+      absoluteTemplatePath,
+      inputObject[0]
+    )
+  );
+} catch (e) {
+  // Opps - error out!
+  console.log(`ERROR: transformDelimited - ${e.message}`);
+}
 
 /**
  * Helpers
@@ -39,30 +60,35 @@ function programSetup(program) {
   program
     .version(pkg.version)
     .description(
-      `Transforms an incoming json string by applying a handlebars/mustache template that is passed by file path as an argument.`
+      `Transforms an incoming delimited string by applying a handlebars/mustache template that is passed by file path as an argument.`
     )
     .option(
       '-t, --template </path/to/your/template.extension>',
       'The full path to the template file to be used.'
     )
     .option(
-      '-i, --inputdata <"json string">',
-      'Pass in a stringified valid JSON object.'
+      '-i, --inputdata <"john", "smith", 1969, "Davenport, FL">',
+      'Pass in a string delimited by the passed in --delimiter. Column values that contain the delimiter should be quoted.'
+    )
+    .option(
+      '-d, --delimiter <"," or "|" or "\\t" or other>',
+      'Pass in a character that delimits the individual columns in your input string.'
+    )
+    .option(
+      '-c, --columnLayout <"column_name, other_column_name">',
+      'Pass in a string of comma separated column names. These will be the names you use in your template file.'
     )
     .parse(process.argv);
 
   // Ensure we received mandatory parameters.
-  if (!program.template || !program.inputdata) {
+  if (
+    !program.template ||
+    !program.inputdata ||
+    !program.columnLayout ||
+    !program.delimiter
+  ) {
     program.outputHelp();
     process.exit(-1);
-  }
-
-  // Parse out the JSON
-  inputObject = JSONHelper.parseJson(program.inputdata);
-  if (!inputObject) {
-    program.outputHelp();
-    console.log(`\n>>> ERROR: the parameter "inputjson" was not valid JSON!`);
-    process.exit(-2);
   }
 
   try {


### PR DESCRIPTION
- To be consistent and make it easier to test, spun out a new class JSONHelper.
- Tweaks to template helper to make it easier to test.
- New class XSVHelper to handle the delimited string parsing (using the excellent csv-parse package.)
- New template demo-simple-flat more suitable for demonstrating/testing the CSV transformation.
- Tweaks to demo-simple to make it more compact.
- New test suite for JSONHelper.
- Tweaks to the test suite for TemplateHelper.
- New test suite for XSVHelper.
- Corresponding README updates for all of the above.
- Refactored transformJSON (tweaked CLI options and spun out the JSON parsing.)
- New root script, transformDelimited.
- Exported the two new classes in the main module so that others can use them directly.
- Bumped package version to 1.1.0 (new functionality, but non-breaking for the prior features.)