### PR TITLE
Optimize template helper

### DIFF
--- a/lib/TemplateHelper.js
+++ b/lib/TemplateHelper.js
@@ -12,6 +12,9 @@ const assert = require('assert');
  * A class to manage all template operations.
  */
 class TemplateHelper {
+  // cacheCompiledTemplates: This is used to cache compiled handlebars templates.
+  static cacheCompiledTemplates = {};
+
   /**
    * Applies a template (by file name) to the passed data. Optionally removes newline characters from the output.
    *
@@ -34,7 +37,8 @@ class TemplateHelper {
   }
 
   /**
-   * Applies a template (by file name) to the passed data. Optionally removes newline characters from the output.
+   * Applies a template (by file name) to the passed data. Optionally removes newline characters from the output. This also caches
+   * compiled templates to avoid recompiling the same template. Caching can make as much as 10 times difference in processing time in some applications
    *
    * @param templateBody
    * @param contextData
@@ -47,8 +51,19 @@ class TemplateHelper {
       templateBody,
       'applyTemplate ERROR: templateBody must not be empty!'
     );
-    const templateRuntime = handlebars.compile(templateBody);
+
+    // Use the cached template if available, else compile a new template
+    const templateRuntime =
+      this.cacheCompiledTemplates[templateBody] ||
+      handlebars.compile(templateBody);
+
+    // Cache the template
+    this.cacheCompiledTemplates[templateBody] = templateRuntime;
+
+    // Apply the template
     const appliedResult = templateRuntime(contextData);
+
+    // Remove new line
     if (removeNewline) {
       return appliedResult.replace(/\n/g, '');
     } else {

--- a/lib/TemplateHelper.js
+++ b/lib/TemplateHelper.js
@@ -8,13 +8,12 @@ const XSVHelper = require('./XSVHelper.js');
 const OutputRedirectHelper = require('./OutputRedirectHelper.js');
 const assert = require('assert');
 
+// cacheCompiledTemplates: This is used to cache compiled handlebars templates.
+const cacheCompiledTemplates = {};
 /**
  * A class to manage all template operations.
  */
 class TemplateHelper {
-  // cacheCompiledTemplates: This is used to cache compiled handlebars templates.
-  static cacheCompiledTemplates = {};
-
   /**
    * Applies a template (by file name) to the passed data. Optionally removes newline characters from the output.
    *
@@ -299,5 +298,5 @@ class TemplateHelper {
     });
   }
 }
-
+TemplateHelper.cacheCompiledTemplates = cacheCompiledTemplates;
 module.exports = TemplateHelper;

--- a/node_modules/commander/package.json
+++ b/node_modules/commander/package.json
@@ -1,27 +1,32 @@
 {
-  "_from": "commander@^5.0.0",
+  "_args": [
+    [
+      "commander@5.0.0",
+      "/Users/danielmorris/work/valtech/u658/modules/super-transformer"
+    ]
+  ],
+  "_from": "commander@5.0.0",
   "_id": "commander@5.0.0",
   "_inBundle": false,
   "_integrity": "sha512-JrDGPAKjMGSP1G0DUoaceEJ3DZgAfr/q6X7FVk4+U5KxUSKviYGM2k6zWkfyyBHy5rAtzgYJFa1ro2O9PtoxwQ==",
   "_location": "/commander",
   "_phantomChildren": {},
   "_requested": {
-    "type": "range",
+    "type": "version",
     "registry": true,
-    "raw": "commander@^5.0.0",
+    "raw": "commander@5.0.0",
     "name": "commander",
     "escapedName": "commander",
-    "rawSpec": "^5.0.0",
+    "rawSpec": "5.0.0",
     "saveSpec": null,
-    "fetchSpec": "^5.0.0"
+    "fetchSpec": "5.0.0"
   },
   "_requiredBy": [
     "/"
   ],
   "_resolved": "https://registry.npmjs.org/commander/-/commander-5.0.0.tgz",
-  "_shasum": "dbf1909b49e5044f8fdaf0adc809f0c0722bdfd0",
-  "_spec": "commander@^5.0.0",
-  "_where": "/Users/eric/Develop/projects/mjd-univ/universal-p658-log-transformation-library",
+  "_spec": "5.0.0",
+  "_where": "/Users/danielmorris/work/valtech/u658/modules/super-transformer",
   "author": {
     "name": "TJ Holowaychuk",
     "email": "tj@vision-media.ca"
@@ -29,9 +34,7 @@
   "bugs": {
     "url": "https://github.com/tj/commander.js/issues"
   },
-  "bundleDependencies": false,
   "dependencies": {},
-  "deprecated": false,
   "description": "the complete solution for node.js command-line programs",
   "devDependencies": {
     "@types/jest": "^25.1.4",

--- a/node_modules/simple-mock/.npmignore
+++ b/node_modules/simple-mock/.npmignore
@@ -1,0 +1,5 @@
+.npmrc
+.travis.yml
+examples
+bower.json
+test.js

--- a/node_modules/simple-mock/LICENSE
+++ b/node_modules/simple-mock/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Pieter Raubenheimer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/node_modules/simple-mock/README.md
+++ b/node_modules/simple-mock/README.md
@@ -1,0 +1,240 @@
+# simple-mock
+
+[![travis][travis-image]][travis-url]
+[![npm][npm-image]][npm-url]
+[![downloads][downloads-image]][downloads-url]
+
+[travis-image]: https://img.shields.io/travis/jupiter/simple-mock.svg?style=flat
+[travis-url]: https://travis-ci.org/jupiter/simple-mock
+[npm-image]: https://img.shields.io/npm/v/simple-mock.svg?style=flat
+[npm-url]: https://npmjs.org/package/simple-mock
+[downloads-image]: https://img.shields.io/npm/dm/simple-mock.svg?style=flat
+[downloads-url]: https://npmjs.org/package/simple-mock
+
+Super simple stubs and spies with 1-step sandbox restore.
+
+## Install
+
+For Node:
+
+```
+$ npm install simple-mock
+```
+
+For Browser:
+
+```
+$ bower install simple-mock
+```
+
+## Mock
+
+Not sure when to use a mock, stub, or spy? Just use `simple.mock`.
+
+Examples:
+
+```js
+var simple = require('simple-mock')
+
+simple.mock(obj, 'example', 'value') // Replace with this value
+
+simple.mock(obj, 'example') // Spy on underlying method *or* stub
+simple.mock(obj, 'example').callFn(function () {}) // Stub
+simple.mock(obj, 'example').callbackWith(null, 'etc') // Stub
+simple.mock(obj, 'example').returnWith('etc') // Stub
+simple.mock(obj, 'example').throwWith(new Error()) // Stub
+simple.mock(obj, 'example').resolveWith('etc') // Stub
+simple.mock(obj, 'example').rejectWith(new Error()) // Stub
+simple.mock(obj, 'example').callOriginal() // Unstubbed call
+```
+
+Then, to make sure all objects are back to the state the were in before your mocks:
+
+```js
+simple.restore() // Ideally called in an afterEach() block
+```
+
+`callbackWith`, `returnWith` and `throwWith` can be chained for queued behaviour, e.g.
+
+```js
+simple.mock(Something.prototype, 'example')
+  .callbackWith(null, 'etc')
+  .callbackWith(new Error())
+```
+
+`callbackWith`, `returnWith` and `throwWith` configurations are stored on a simple array fn.actions
+
+## Expectations
+
+You define your expectations with *your own choice* of assertion library.
+
+```js
+assert(fn.called)
+assert.equals(fn.callCount, 3)
+assert.equals(fn.lastCall.arg, error) // First parameter of the last call
+assert.equals(fn.lastCall.args[1], 'etc') // Second parameter of the last call
+assert.equals(fn.calls[0].returned, 'etc')
+assert.equals(fn.calls[1].threw, error)
+```
+
+## Standalone Stubs and Spies
+
+If you need to create a standalone stub (stubs are also spies):
+
+```js
+var fn = simple.stub().returnWith('etc')
+
+var returned = fn()
+
+assert.equals(returned, 'etc')
+```
+
+Or spy on a standalone function:
+
+```js
+var fn = simple.spy(function () {})
+
+assert.equals(fn.callCount, 0)
+assert.equals(fn.calls, [])
+```
+
+See [examples](examples) for more common usage patterns.
+
+## API
+
+For `var simple = require('simple-mock')`:
+
+### simple.mock(obj, key, value)
+
+Sets the value on this object. E.g. `mock(config, 'title', 'test')` is the same as `config.title = 'test'`, but restorable with all mocks.
+
+### simple.mock(obj, key, fn)
+
+Wraps `fn` in a spy and sets this on the `obj`, restorable with all mocks.
+
+### simple.mock(obj, key)
+
+If `obj` has already has this function, it is wrapped in a spy. The resulting spy can be turned into a stub by further configuration. Restores with all mocks.
+
+### simple.restore()
+
+Restores all current mocks.
+
+### simple.restore(obj, key)
+
+Use this if you need to restore only a single mock value or function on an object.
+
+### simple.spy(fn) *or* simple.mock(fn)
+
+Wraps `fn` in a spy.
+
+### simple.stub() *or* simple.mock()
+
+Returns a stub function that is also a spy.
+
+---
+
+### spy.called
+
+Boolean
+
+### spy.callCount
+
+Number of times the function was called.
+
+### spy.calls
+
+An array of calls, each having these properties:
+
+- **call.args** an array of arguments received on the call
+- **call.context** the context (`this`) of the call
+- **call.returned** the value returned by the wrapped function
+- **call.threw** the error thrown by the wrapped function
+- **call.k** autoincrementing number, can be compared to evaluate call order
+
+### spy.lastCall
+
+The last call object, with properties as above. (This is often also the first and only call.)
+
+### spy.reset()
+
+Resets all counts and properties to the original state.
+
+---
+
+### stub.callFn(fn)
+
+Configures this stub to call this function, returning its return value. Subsequent calls of this on the same stub (chainable) will queue up different behaviours for each subsequent call of the stub.
+
+### stub.callOriginal()
+
+Configures this stub to call the original, unstubbed function, returning its return value. Subsequent calls of this on the same stub (chainable) will queue up different behaviours for each subsequent call of the stub.
+
+
+### stub.returnWith(val)
+
+Configures this stub to return with this value. Subsequent calls of this on the same stub (chainable) will queue up different behaviours for each subsequent call of the stub.
+
+### stub.throwWith(err)
+
+Configures this stub to throw this error. Subsequent calls of this on the same stub (chainable) will queue up different behaviours for each subsequent call of the stub.
+
+### stub.callback(...) *or* stub.callbackAtIndex(cbArgumentIndex, ...)
+
+Configures this stub to call back with the arguments passed. It will use either the last argument as callback, or the argument at `cbArgumentIndex`. Subsequent calls of this on the same stub (chainable) will queue up different behaviours for each subsequent call of the stub.
+
+### stub.inThisContext(obj)
+
+Configures the last configured function or callback to be called in this context, i.e. `this` will be `obj`.
+
+### stub.resolveWith(val)
+
+Configures the stub to return a Promise (where available] resolving to this value. Same as `stub.returnWith(Promise.resolve(val))`. You can use a custom Promise-conforming library, i.e. `simple.Promise = require('bluebird')` or `simple.Promise = $q`.
+
+### stub.rejectWith(val)
+
+Configures the stub to return a Promise (where available) rejecting with this error. Same as `stub.returnWith(Promise.reject(val))`. You can use a custom Promise-conforming library, i.e. `simple.Promise = require('bluebird')` or `simple.Promise = $q`.
+
+### stub.actions
+
+An array of behaviours, each having *one* of these properties:
+
+- **action.cbArgs** arguments to call back with
+- **action.returnValue**
+- **action.throwError**
+
+Note: modifying this array directly is not supported, rather use stub.withActions(actions) if you need to add actions.
+
+### stub.withActions(actions) *or* stub.withActions()
+
+Configures this stub to use the specified array of actions. See `stub.actions` above for the syntax of an action.
+
+```js
+var fn = simple.stub()
+         .returnWith('a')
+         .withActions([{ returnValue: 'b' }, { returnValue: 'c' }])
+         .returnWith('d')
+
+var returned1 = fn()
+var returned2 = fn()
+var returned3 = fn()
+var returned4 = fn()
+
+assert.equal(fn.callCount, 4)
+assert.equal(returned1, 'a')
+assert.equal(returned2, 'b')
+assert.equal(returned3, 'c')
+assert.equal(returned4, 'd')
+```
+
+### stub.loop
+
+Boolean (default: true) setting whether the queue of actions for this stub should repeat.
+
+### stub.withLoop() & stub.noLoop()
+
+Configures the stub to enable/disable [looping](#stubloop).
+
+## Why
+
+The most complete, framework-agnostic mocking library is [sinon.js](http://sinonjs.org/). It also has pages of documentation and lots of sugar-coating that we generally don't need. Keep it simple!

--- a/node_modules/simple-mock/index.js
+++ b/node_modules/simple-mock/index.js
@@ -1,0 +1,240 @@
+/* global define */
+(function (global, module) { // Browser compatibility
+  var simple = module.exports
+  var mocks = []
+  var totalCalls = 0
+
+  /**
+   * Restore the current simple and create a new one
+   *
+   * @param {Object} [obj]
+   * @param {String} [key]
+   * @api public
+   */
+  simple.restore = function (obj, key) {
+    if (obj && key) {
+      mocks.some(function (mock, i) {
+        if (mock.obj !== obj || mock.key !== key) return
+
+        mock.restore()
+        mocks.splice(i, 1)
+        return true
+      })
+      return
+    }
+
+    mocks.forEach(_restoreMock)
+    mocks = []
+  }
+
+  /**
+   * Create a mocked value on an object
+   *
+   * @param {Object} obj
+   * @param {String} key
+   * @param {Function|Value} mockValue
+   * @return {Function} mock
+   * @api public
+   */
+  simple.mock = function (obj, key, mockValue) {
+    if (!arguments.length) {
+      return simple.spyOrStub()
+    } else if (arguments.length === 1) {
+      return simple.spyOrStub(obj)
+    } else if (isFunction(mockValue)) {
+      mockValue = simple.spyOrStub(mockValue)
+    } else if (arguments.length === 2) {
+      mockValue = simple.spyOrStub(obj, key)
+    }
+
+    var mock = {
+      obj: obj,
+      key: key,
+      mockValue: mockValue,
+      oldValue: obj[key],
+      oldValueHasKey: (key in obj)
+    }
+
+    mock.restore = _restoreMock.bind(null, mock)
+    mocks.unshift(mock)
+
+    obj[key] = mockValue
+    return mockValue
+  }
+
+  /**
+   * Create a stub function
+   *
+   * @param {Function|Object} wrappedFn
+   * @param {String} [key]
+   * @return {Function} spy
+   * @api public
+   */
+  simple.spyOrStub = simple.stub = simple.spy = function (wrappedFn, key) {
+    if (arguments.length === 2) {
+      wrappedFn = wrappedFn[key]
+    }
+
+    var originalFn = wrappedFn
+
+    var stubFn = function () {
+      var action = (newFn.loop) ? newFn.actions[(newFn.callCount - 1) % newFn.actions.length] : newFn.actions.shift()
+
+      if (!action) return
+      if (action.throwError) throw action.throwError
+      if ('returnValue' in action) return action.returnValue
+      if ('fn' in action) return action.fn.apply(action.ctx || this, arguments)
+
+      var cb = ('cbArgIndex' in action) ? arguments[action.cbArgIndex] : arguments[arguments.length - 1]
+      if (action.cbArgs) return cb.apply(action.ctx || null, action.cbArgs)
+    }
+
+    var newFn = function () {
+      var call = {
+        k: totalCalls++, // Keep count of calls to record the absolute order of calls
+        args: Array.prototype.slice.call(arguments, 0),
+        arg: arguments[0],
+        context: this
+      }
+      newFn.calls.push(call)
+      newFn.firstCall = newFn.firstCall || call
+      newFn.lastCall = call
+      newFn.callCount++
+      newFn.called = true
+
+      try {
+        call.returned = (wrappedFn || _noop).apply(this, arguments)
+      } catch(e) {
+        call.threw = e
+        throw e
+      }
+      return call.returned
+    }
+
+    // Spy
+    newFn.reset = function () {
+      newFn.calls = []
+      newFn.lastCall = { args: [] } // For dot-safety
+      newFn.callCount = 0
+      newFn.called = false
+    }
+    newFn.reset()
+
+    // Stub
+    newFn.actions = []
+    newFn.loop = true
+
+    newFn.callbackWith = newFn.callback = function () {
+      wrappedFn = stubFn
+      newFn.actions.push({ cbArgs: arguments })
+      return newFn // Chainable
+    }
+
+    newFn.callbackArgWith = newFn.callbackAtIndex = function () {
+      wrappedFn = stubFn
+      newFn.actions.push({
+        cbArgs: Array.prototype.slice.call(arguments, 1),
+        cbArgIndex: arguments[0]
+      })
+      return newFn // Chainable
+    }
+
+    newFn.inThisContext = function (obj) {
+      var action = newFn.actions[newFn.actions.length - 1]
+      action.ctx = obj
+      return newFn // Chainable
+    }
+
+    newFn.withArgs = function () {
+      var action = newFn.actions[newFn.actions.length - 1]
+      action.cbArgs = arguments
+      return newFn // Chainable
+    }
+
+    newFn.returnWith = function (returnValue) {
+      wrappedFn = stubFn
+      newFn.actions.push({ returnValue: returnValue })
+      return newFn // Chainable
+    }
+
+    newFn.throwWith = function (err) {
+      wrappedFn = stubFn
+      newFn.actions.push({ throwError: err })
+      return newFn // Chainable
+    }
+
+    newFn.resolveWith = function (value) {
+      if (simple.Promise.when) return newFn.callFn(function createResolvedPromise () { return simple.Promise.when(value) })
+      return newFn.callFn(function createResolvedPromise () { return simple.Promise.resolve(value) })
+    }
+
+    newFn.rejectWith = function (value) {
+      return newFn.callFn(function createRejectedPromise () { return simple.Promise.reject(value) })
+    }
+
+    newFn.callFn = function (fn) {
+      wrappedFn = stubFn
+      newFn.actions.push({ fn: fn })
+      return newFn // Chainable
+    }
+
+    newFn.withActions = function (actions) {
+      wrappedFn = stubFn
+      if (actions && actions.length >= 0) {
+        Array.prototype.push.apply(newFn.actions, actions)
+      }
+      return newFn // Chainable
+    }
+
+    newFn.callOriginal = newFn.callOriginalFn = function () {
+      wrappedFn = stubFn
+      newFn.actions.push({ fn: originalFn })
+      return newFn // Chainable
+    }
+
+    newFn.withLoop = function () {
+      newFn.loop = true
+      return newFn // Chainable
+    }
+
+    newFn.noLoop = function () {
+      newFn.loop = false
+      return newFn // Chainable
+    }
+    return newFn
+  }
+
+  function _restoreMock (mock) {
+    if (!mock.oldValueHasKey) {
+      delete mock.obj[mock.key]
+      return
+    }
+    mock.obj[mock.key] = mock.oldValue
+  }
+
+  function _noop () {}
+
+  /**
+   * Return whether the passed variable is a function
+   *
+   * @param {Mixed} value
+   * @return {Boolean}
+   * @api private
+   */
+  function isFunction (value) {
+    return Object.prototype.toString.call(value) === funcClass
+  }
+  var funcClass = '[object Function]'
+
+  // Browser compatibility
+  if (typeof define === 'function' && define.amd) {
+    define(function () {
+      return simple
+    })
+  } else if (typeof window !== 'undefined') {
+    window.simple = simple
+  }
+
+  // Native Promise support
+  if (typeof Promise !== 'undefined') simple.Promise = Promise
+})(this, typeof module !== 'undefined' ? module : {exports: {}})

--- a/node_modules/simple-mock/package.json
+++ b/node_modules/simple-mock/package.json
@@ -1,0 +1,63 @@
+{
+  "_from": "simple-mock",
+  "_id": "simple-mock@0.8.0",
+  "_inBundle": false,
+  "_integrity": "sha1-ScmiI/pu6o4sT9aUj+gwDNillPM=",
+  "_location": "/simple-mock",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "tag",
+    "registry": true,
+    "raw": "simple-mock",
+    "name": "simple-mock",
+    "escapedName": "simple-mock",
+    "rawSpec": "",
+    "saveSpec": null,
+    "fetchSpec": "latest"
+  },
+  "_requiredBy": [
+    "#DEV:/",
+    "#USER"
+  ],
+  "_resolved": "https://registry.npmjs.org/simple-mock/-/simple-mock-0.8.0.tgz",
+  "_shasum": "49c9a223fa6eea8e2c4fd6948fe8300cd8a594f3",
+  "_spec": "simple-mock",
+  "_where": "/Users/danielmorris/work/valtech/u658/modules/super-transformer",
+  "author": {
+    "name": "Pieter Raubenheimer"
+  },
+  "bugs": {
+    "url": "https://github.com/jupiter/simple-mock/issues"
+  },
+  "bundleDependencies": false,
+  "dependencies": {},
+  "deprecated": false,
+  "description": "Super simple stubs and spies with 1-step sandbox restore",
+  "devDependencies": {
+    "mocha": "^2.2.5",
+    "standard": "^4.0.1"
+  },
+  "homepage": "https://github.com/jupiter/simple-mock",
+  "keywords": [
+    "test",
+    "simplemock",
+    "simple",
+    "mock",
+    "stub",
+    "spy",
+    "fake"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "name": "simple-mock",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jupiter/simple-mock.git"
+  },
+  "scripts": {
+    "npmrc": "printf \"_auth = $NPM_AUTH_TOKEN\nemail = $NPM_EMAIL\n\" > .npmrc",
+    "test": "npm run test-no-publish && if [ -n \"${TRAVIS_TAG}\" ]; then npm run npmrc && npm publish || 1; fi",
+    "test-no-publish": "standard && mocha"
+  },
+  "version": "0.8.0"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "super-transformer",
-  "version": "1.0.5",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -773,6 +773,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "simple-mock": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/simple-mock/-/simple-mock-0.8.0.tgz",
+      "integrity": "sha1-ScmiI/pu6o4sT9aUj+gwDNillPM=",
       "dev": true
     },
     "source-map": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "super-transformer",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "This package provides scripts to transform incoming strings and files using templates. It receives a file path or a string in various formats (JSON, CSV) and returns transformed data.",
   "author": "Eric Soto <eric.soto@valtech.com>",
   "main": "index.js",
@@ -18,8 +18,9 @@
     "csv-parse": "^4.8.9"
   },
   "devDependencies": {
-    "prettier": "^2.0.5",
+    "chai": "^4.2.0",
     "mocha": "^7.1.1",
-    "chai": "^4.2.0"
+    "prettier": "^2.0.5",
+    "simple-mock": "^0.8.0"
   }
 }


### PR DESCRIPTION
Make so handlebars compile is cached using a static variable.

While caching does technically introduce state into a static class, it is a large enough of an optimization for all users that I believe it is worth doing. It is caching something that is guaranteed to have the same output every-time anyway.

Running transformations on my local machine with handlebars compile caching vs without was a difference of 14ms per record vs under 1ms per record